### PR TITLE
Tabata/user books index

### DIFF
--- a/app/controllers/user_books_controller.rb
+++ b/app/controllers/user_books_controller.rb
@@ -7,19 +7,20 @@ class UserBooksController < ApplicationController
   end
   
   def create
-    @userBook = UserBook.new(user_book_params)
-    @userBook[:user_id] = current_user.id
+    @userBook = UserBook.new(
+      title: user_book_params[:title],
+      author: user_book_params[:author],
+      user_id: current_user.id
+    )
     user_book_image_parsed = URI.parse(user_book_params[:user_book_image])
     if user_book_image_parsed.path != "/user_books/new"
     # 画像があった場合
       f = open user_book_params[:user_book_image]
       @userBook.user_book_image.attach io: f, filename: File.basename(f)
-    else
-    # 画像がなかった場合
-      @userBook.user_book_image = nil
     end
     @userBook.save
   end
+  
   
   def user_book_params
     params.permit(:title, :author, :user_book_image)

--- a/app/controllers/user_books_controller.rb
+++ b/app/controllers/user_books_controller.rb
@@ -7,8 +7,13 @@ class UserBooksController < ApplicationController
   
   def create
     @userBook = UserBook.new(user_book_params)
-    f = open user_book_params[:user_book_image]
-    @userBook.user_book_image.attach io: f, filename: File.basename(f)
+    begin
+      f = open user_book_params[:user_book_image]
+      @userBook.user_book_image.attach io: f, filename: File.basename(f)
+    rescue => e
+      logger.error e
+    end
+    
     @userBook[:user_id] = current_user.id
     @userBook.save
     

--- a/app/controllers/user_books_controller.rb
+++ b/app/controllers/user_books_controller.rb
@@ -1,5 +1,6 @@
 class UserBooksController < ApplicationController
   require 'open-uri'
+  require 'uri'
   before_action :authenticate_user!
   
   def new
@@ -7,18 +8,18 @@ class UserBooksController < ApplicationController
   
   def create
     @userBook = UserBook.new(user_book_params)
-    begin
+    @userBook[:user_id] = current_user.id
+    user_book_image_parsed = URI.parse(user_book_params[:user_book_image])
+    if user_book_image_parsed.path != "/user_books/new"
+    # 画像があった場合
       f = open user_book_params[:user_book_image]
       @userBook.user_book_image.attach io: f, filename: File.basename(f)
-    rescue => e
-      logger.error e
+    else
+    # 画像がなかった場合
+      @userBook.user_book_image = nil
     end
-    
-    @userBook[:user_id] = current_user.id
     @userBook.save
-    
   end
-  
   
   def user_book_params
     params.permit(:title, :author, :user_book_image)

--- a/app/controllers/user_books_controller.rb
+++ b/app/controllers/user_books_controller.rb
@@ -27,7 +27,6 @@ class UserBooksController < ApplicationController
   end
   
   def edit
-    @category = Category.new
   end
 
   def update
@@ -36,15 +35,16 @@ class UserBooksController < ApplicationController
         author: user_book_update_params[:author],
         feeling: user_book_update_params[:feeling]
       )
-      @userCategory = UserCategory.new(
-        user_book_id: @userBook.id,
-        category_id: user_book_update_params[:category_ids]
+      @userCategory = UserCategory.find_or_initialize_by(
+        user_book_id: @userBook.id
       )
+      @userCategory.category_id = user_book_update_params[:category_ids]
       @userCategory.save!
-      @userFeelingCategory = UserFeelingCategory.new(
-        user_book_id: @userBook.id,
-        feeling_category_id: user_book_update_params[:feeling_category_ids]
+      
+      @userFeelingCategory = UserFeelingCategory.find_or_initialize_by(
+        user_book_id: @userBook.id
       )
+      @userFeelingCategory.feeling_category_id = user_book_update_params[:feeling_category_ids]
       @userFeelingCategory.save!
       redirect_to user_books_url
     else

--- a/app/controllers/user_books_controller.rb
+++ b/app/controllers/user_books_controller.rb
@@ -2,6 +2,11 @@ class UserBooksController < ApplicationController
   require 'open-uri'
   require 'uri'
   before_action :authenticate_user!
+  before_action :set_user_book, only: [:edit, :show, :destroy, :update]
+  
+  def index
+    @userBooks = UserBook.all
+  end
   
   def new
   end
@@ -21,8 +26,37 @@ class UserBooksController < ApplicationController
     @userBook.save
   end
   
+  def edit
+  end
+
+  def update
+    if @userBook.update(
+        title: user_book_update_params[:title],
+        author: user_book_update_params[:author],
+        feeling: user_book_update_params[:feeling]
+      )
+      redirect_to user_books_url
+    else
+      render :edit
+    end
+  end
+  
+  def destroy
+    @userBook.destroy
+    redirect_to user_books_url
+  end
   
   def user_book_params
     params.permit(:title, :author, :user_book_image)
   end
+  
+  def user_book_update_params
+    params.require(:user_book).permit(:title, :author, :feeling_category, :feeling)
+    params.require(:category).permit(:category_name)
+  end
+  
+  def set_user_book
+    @userBook = UserBook.find(params[:id]) 
+  end
+  
 end

--- a/app/controllers/user_books_controller.rb
+++ b/app/controllers/user_books_controller.rb
@@ -27,6 +27,7 @@ class UserBooksController < ApplicationController
   end
   
   def edit
+    @category = Category.new
   end
 
   def update
@@ -35,6 +36,16 @@ class UserBooksController < ApplicationController
         author: user_book_update_params[:author],
         feeling: user_book_update_params[:feeling]
       )
+      @userCategory = UserCategory.new(
+        user_book_id: @userBook.id,
+        category_id: user_book_update_params[:category_ids]
+      )
+      @userCategory.save!
+      @userFeelingCategory = UserFeelingCategory.new(
+        user_book_id: @userBook.id,
+        feeling_category_id: user_book_update_params[:feeling_category_ids]
+      )
+      @userFeelingCategory.save!
       redirect_to user_books_url
     else
       render :edit
@@ -51,10 +62,9 @@ class UserBooksController < ApplicationController
   end
   
   def user_book_update_params
-    params.require(:user_book).permit(:title, :author, :feeling_category, :feeling)
-    params.require(:category).permit(:category_name)
+    params.require(:user_book).permit(:title, :author, :feeling_category, :feeling, :category_ids, :feeling_category_ids)
   end
-  
+    
   def set_user_book
     @userBook = UserBook.find(params[:id]) 
   end

--- a/app/javascript/packs/hello_vue.js
+++ b/app/javascript/packs/hello_vue.js
@@ -6,7 +6,7 @@
 // All it does is render <div>Hello Vue</div> at the bottom of the page.
 
 import Vue from 'vue'
-import App from '../parts/book_list.vue'
+import BookList from '../parts/book_list.vue'
 import axios from 'axios';
 
 axios.defaults.headers.common = {
@@ -16,11 +16,11 @@ axios.defaults.headers.common = {
 Vue.prototype.$http = axios
 
 document.addEventListener('DOMContentLoaded', () => {
-  const app = new Vue({
-    render: h => h(App)
+  const bookList = new Vue({
+    render: h => h(BookList)
   }).$mount()
   var element = document.getElementById('bookForm');
-  element.append(app.$el)
+  element.append(bookList.$el)
 })
 
 

--- a/app/javascript/parts/book_list.vue
+++ b/app/javascript/parts/book_list.vue
@@ -22,7 +22,7 @@
 
 <script>
 export default {
-  name: 'HelloWorld',
+  name: 'BookList',
   data: function () {
     return {
       results: [],
@@ -30,14 +30,14 @@ export default {
     }
   },
   async mounted() {
-    console.log(123)
+    console.log(1)
   },
   methods: {
     searchBooks: async function(query) {
-      var endpoint = 'https://www.googleapis.com/books/v1';
+      var apiUrl = 'https://www.googleapis.com/books/v1';
   
       // 検索 API を叩く
-      var res = await fetch(`${endpoint}/volumes?q=${query}`);
+      var res = await fetch(`${apiUrl}/volumes?q=${query}`);
       // JSON に変換
       var data = await res.json();
       
@@ -52,7 +52,6 @@ export default {
           image: vi.imageLinks ? vi.imageLinks.smallThumbnail : '',
         }; 
       });
-      
       return items;
     },
     changeBooks: async function(){
@@ -62,8 +61,7 @@ export default {
         return
       }
       var items = await this.searchBooks(value);
-      console.log(items)
-      
+      console.log(items);
       this.results = items;  
     },
     createBook: function(index){
@@ -71,13 +69,13 @@ export default {
       const $author = document.getElementById('author'+index);
       const $image = document.getElementById('image'+index);
       const urlString = $image.src.replace('http://','https://');
-      console.log(urlString)
       const data = new FormData();
+      console.log(data);
       data.append("title", $title.value);
       data.append("author", $author.value);
       data.append("user_book_image", urlString);
+      console.log(data.get('title'));
       const headers = { "content-type": "multipart/form-data" };
-      console.log($title)
       this.$http
       .post(
         '/user_books',

--- a/app/javascript/parts/book_list.vue
+++ b/app/javascript/parts/book_list.vue
@@ -52,6 +52,7 @@ export default {
           image: vi.imageLinks ? vi.imageLinks.smallThumbnail : '',
         }; 
       });
+      console.log("searchBooks");
       return items;
     },
     changeBooks: async function(){
@@ -60,6 +61,7 @@ export default {
         this.results = ''
         return
       }
+      console.log("changeBooks");
       var items = await this.searchBooks(value);
       console.log(items);
       this.results = items;  

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,2 +1,4 @@
 class Category < ApplicationRecord
+    has_many :user_categories
+    has_many :user_books, through: :user_categories
 end

--- a/app/models/feeling_category.rb
+++ b/app/models/feeling_category.rb
@@ -1,2 +1,4 @@
 class FeelingCategory < ApplicationRecord
+    has_many :user_feeling_categories
+    has_many :user_books, through: :user_feeling_categories
 end

--- a/app/models/user_book.rb
+++ b/app/models/user_book.rb
@@ -1,4 +1,8 @@
 class UserBook < ApplicationRecord
   belongs_to :user
   has_one_attached :user_book_image
+  has_many :user_categories
+  has_many :categories, through: :user_categories
+  has_many :user_feeling_categories
+  has_many :feeling_categories, through: :user_feeling_categories
 end

--- a/app/models/user_category.rb
+++ b/app/models/user_category.rb
@@ -1,3 +1,4 @@
 class UserCategory < ApplicationRecord
   belongs_to :user_book
+  belongs_to :category
 end

--- a/app/models/user_feeling_category.rb
+++ b/app/models/user_feeling_category.rb
@@ -1,3 +1,4 @@
 class UserFeelingCategory < ApplicationRecord
   belongs_to :user_book
+  belongs_to :feeling_category
 end

--- a/app/views/user_books/edit.html.erb
+++ b/app/views/user_books/edit.html.erb
@@ -18,8 +18,8 @@
     <div>
         <label>読後感</label><br>
         <%= f.collection_select :feeling_category_ids, FeelingCategory.all, :id, :feeling_after_reading, include_blank: "選択して下さい" %>
+        <%= text_field :user_feeling_category, :stars %>
     </div>
-    
     <div>
         <label>感想</label><br>
         <%= f.text_area :feeling %>

--- a/app/views/user_books/edit.html.erb
+++ b/app/views/user_books/edit.html.erb
@@ -2,25 +2,26 @@
 <span>現在ログイン中のユーザー：<%= current_user.name %></span>
 <%= form_for(@userBook, url: user_book_path(@userBook)) do |f| %>
     <div>
-        <%= f.label :タイトル %><br>
+        <label>タイトル</label><br>
         <%= f.text_field :title, autofocus: true %>
     </div>
     <div>
-        <%= f.label :著者 %><br>
+        <label>著者</label><br>
         <%= f.text_field :author %>
     </div>
+    
     <div>
-        <%= f.label :カテゴリー %><br>
-        <%= text_field :category, :category_name %>
+        <label>カテゴリー</label><br>
+        <%= f.collection_select :category_ids, Category.all, :id, :category_name, include_blank: "選択して下さい" %>
+    </div>
+
+    <div>
+        <label>読後感</label><br>
+        <%= f.collection_select :feeling_category_ids, FeelingCategory.all, :id, :feeling_after_reading, include_blank: "選択して下さい" %>
     </div>
     
     <div>
-        <%#= f.label :読後感 %><br>
-        <%#= f.text_field :feeling_category %>
-    </div>
-    
-    <div>
-        <%= f.label :感想 %><br>
+        <label>感想</label><br>
         <%= f.text_area :feeling %>
     </div>
     

--- a/app/views/user_books/edit.html.erb
+++ b/app/views/user_books/edit.html.erb
@@ -1,0 +1,28 @@
+<h1>Posts#edit</h1>
+<span>現在ログイン中のユーザー：<%= current_user.name %></span>
+<%= form_for(@userBook, url: user_book_path(@userBook)) do |f| %>
+    <div>
+        <%= f.label :タイトル %><br>
+        <%= f.text_field :title, autofocus: true %>
+    </div>
+    <div>
+        <%= f.label :著者 %><br>
+        <%= f.text_field :author %>
+    </div>
+    <div>
+        <%= f.label :カテゴリー %><br>
+        <%= text_field :category, :category_name %>
+    </div>
+    
+    <div>
+        <%#= f.label :読後感 %><br>
+        <%#= f.text_field :feeling_category %>
+    </div>
+    
+    <div>
+        <%= f.label :感想 %><br>
+        <%= f.text_area :feeling %>
+    </div>
+    
+    <div><%= f.submit "更新する" %></div>
+<% end %>

--- a/app/views/user_books/index.html.erb
+++ b/app/views/user_books/index.html.erb
@@ -1,0 +1,25 @@
+<table>
+  <thead>
+    <tr>
+      <th>タイトル</th>
+      <th>著者</th>
+      <th colspan="2"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @userBooks.each do |userBook| %>
+      <tr>
+        <td><%= userBook.title %></td>
+        <td><%= userBook.author %></td>
+        <td>
+          <% if userBook.user_book_image.present? %>
+            <%= image_tag userBook.user_book_image %>
+          <% end %>
+        </td>
+        <td><%= link_to "編集", edit_user_book_path(userBook) %></td>
+        <td><%= link_to "削除", userBook, method: :delete, data: { confirm: "削除してもよろしいですか？" } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/initializers/open-uri.rb
+++ b/config/initializers/open-uri.rb
@@ -1,0 +1,4 @@
+require 'open-uri'
+# Don't allow downloaded files to be created as StringIO. Force a tempfile to be created.
+OpenURI::Buffer.send :remove_const, 'StringMax' if OpenURI::Buffer.const_defined?('StringMax')
+OpenURI::Buffer.const_set 'StringMax', 0


### PR DESCRIPTION
・APIから取得した画像の保存（画像がない場合の処理）
・登録した本の一覧表示
・編集ページの作成
・登録した本の編集機能追加
・登録した本の削除機能追加
・各モデル同士の関連付け
・登録した本のカテゴリー、読後感カテゴリーの登録機能追加
・上記カテゴリー情報が更新されるたび、中間モデルに多数のレコードが保存されないよう修正。