### PR TITLE
Tabata/add new feeling after reading

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1,0 +1,19 @@
+body { 
+  button, input, select, textarea {
+    background-color: transparent;
+    border-style: solid;
+    padding: 1px 2px;
+  }
+
+  button, input, optgroup, select, textarea {
+      font: inherit;
+  }
+
+  input {
+      border-radius: 0;
+  }
+}
+
+.after-reading-container {
+  display: flex;
+}

--- a/app/controllers/user_books_controller.rb
+++ b/app/controllers/user_books_controller.rb
@@ -42,15 +42,17 @@ class UserBooksController < ApplicationController
       @userCategory.category_id = user_book_update_params[:category_ids]
       @userCategory.save!
     end
-    
-    if user_book_update_params[:felling_category_ids].present?
-      @userFeelingCategory = UserFeelingCategory.find_or_initialize_by(
-        user_book_id: @userBook.id
-      )
-    
-      @userFeelingCategory.feeling_category_id = user_book_update_params[:feeling_category_ids]
-      @userFeelingCategory.stars = user_book_update_params[:user_feeling_category_stars]
-      @userFeelingCategory.save!
+    if user_book_update_params[:feeling_category_id].present?
+      @userBook.feeling_categories.destroy_all
+      user_book_update_params[:feeling_category_id].each_with_index do |feeling_category_id, index|
+        @userFeelingCategory = UserFeelingCategory.new(
+          user_book_id: @userBook.id
+        )
+      
+        @userFeelingCategory.feeling_category_id = feeling_category_id
+        @userFeelingCategory.stars = user_book_update_params[:user_feeling_category_star][index]
+        @userFeelingCategory.save!
+      end
     end
     
     if user_book_update_params[:feeling_after_reading].present?
@@ -74,8 +76,8 @@ class UserBooksController < ApplicationController
   
   def user_book_update_params
     params.require(:user_book).permit(:title, :author, :feeling_category, :feeling, 
-                                      :category_ids, :feeling_category_ids,:user_feeling_category_stars,
-                                      :feeling_after_reading
+                                      :category_ids, :feeling_after_reading, :feeling_category_ids,
+                                      user_feeling_category_star: [], feeling_category_id: []
                                      )
   end
     

--- a/app/controllers/user_books_controller.rb
+++ b/app/controllers/user_books_controller.rb
@@ -30,27 +30,37 @@ class UserBooksController < ApplicationController
   end
 
   def update
-    if @userBook.update(
-        title: user_book_update_params[:title],
-        author: user_book_update_params[:author],
-        feeling: user_book_update_params[:feeling]
-      )
+    @userBook.update!(
+      title: user_book_update_params[:title],
+      author: user_book_update_params[:author],
+      feeling: user_book_update_params[:feeling]
+    )
+    if user_book_update_params[:category_ids].present?
       @userCategory = UserCategory.find_or_initialize_by(
         user_book_id: @userBook.id
       )
       @userCategory.category_id = user_book_update_params[:category_ids]
       @userCategory.save!
-      
+    end
+    
+    if user_book_update_params[:felling_category_ids].present?
       @userFeelingCategory = UserFeelingCategory.find_or_initialize_by(
         user_book_id: @userBook.id
       )
+    
       @userFeelingCategory.feeling_category_id = user_book_update_params[:feeling_category_ids]
       @userFeelingCategory.stars = user_book_update_params[:user_feeling_category_stars]
       @userFeelingCategory.save!
-      redirect_to user_books_url
-    else
-      render :edit
     end
+    
+    if user_book_update_params[:feeling_after_reading].present?
+      @feelingCategory = FeelingCategory.find_or_initialize_by(
+        user_id: current_user.id,
+        feeling_after_reading: user_book_update_params[:feeling_after_reading]
+      )
+      @feelingCategory.save!
+    end
+    redirect_to user_books_url
   end
   
   def destroy
@@ -64,7 +74,9 @@ class UserBooksController < ApplicationController
   
   def user_book_update_params
     params.require(:user_book).permit(:title, :author, :feeling_category, :feeling, 
-                                      :category_ids, :feeling_category_ids,:user_feeling_category_stars)
+                                      :category_ids, :feeling_category_ids,:user_feeling_category_stars,
+                                      :feeling_after_reading
+                                     )
   end
     
   def set_user_book

--- a/app/javascript/packs/star_vue.js
+++ b/app/javascript/packs/star_vue.js
@@ -1,20 +1,27 @@
-import Vue from 'vue'
-import StarRating from 'vue-star-rating'
-import StarRatingVue from '../parts/stars.vue'
+import Vue from 'vue';
+import StarRating from 'vue-star-rating';
+import StarRatingVue from '../parts/stars.vue';
+import Vuetify from 'vuetify';
+import 'vuetify/dist/vuetify.min.css';
+import '@mdi/font/css/materialdesignicons.css'
 
-console.log(11)
+Vue.use(Vuetify); // 追加
+const vuetify = new Vuetify(); // 追加
+
+console.log(11);
 
 Vue.component('star-rating', StarRating);
 
 document.addEventListener('DOMContentLoaded', () => {
   console.log(5)
   const starInput = new Vue({
+    vuetify,
     render: h => h(StarRatingVue)
   }).$mount()
   var element = document.getElementById('star_input');
   console.log(4)
   element.append(starInput.$el)
-})
+});
 
 // document.addEventListener('DOMContentLoaded', () => {
 //   const starInput = new Vue({

--- a/app/javascript/parts/book_list.vue
+++ b/app/javascript/parts/book_list.vue
@@ -82,8 +82,9 @@ export default {
       .post(
         '/user_books',
         data,
-        { headers }
+        { headers },
       )
+      window.location.href='/user_books'
     }
   }
 }

--- a/app/javascript/parts/stars.vue
+++ b/app/javascript/parts/stars.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <div class="star-container" v-for="(feeling, index) in feelingCategories" :key="index" >
-      <input type="hidden" :ref="'hidden_stars_'+index" name="user_book[user_feeling_category_stars]" :id="'user_book_user_feeling_category_stars_'+index">
-      <select v-html="feeling.innerHTML" name="user_book[feeling_category_ids]">
+      <input type="hidden" :ref="'hidden_stars_'+index" name="user_book[user_feeling_category_star][]" :id="'user_book_user_feeling_category_stars_'+index">
+      <select v-html="feeling.innerHTML" name="user_book[feeling_category_id][]">
       </select>
       <star-rating @rating-selected ="setRating" v-model="star.rating[index]"></star-rating>
       <v-icon @click="addFeelingCategory" class="plus" large>mdi-plus-circle</v-icon>
@@ -26,19 +26,17 @@ export default {
     }
   },
   async mounted() {
-    var star_value_element = document.getElementById('star_value');
-    var feeling_category_element = document.getElementById('user_book_feeling_category_ids');
-    this.rating = parseInt(star_value_element.value);
-    // this.$refs.hidden_stars.value = this.rating;
+    let star_elements = document.getElementsByName('user_feeling_categories[stars]');
+    let feeling_category_element = document.getElementById('user_book_feeling_category_ids');
     feeling_category_element.hidden = true;
-    // console.log(this.feelingCategoryRefs[0]);
-    // this.feelingCategoryRefs[0].innerHTML = feeling_category_element.innerHTML;
-    // var feeling_category_select_element = document.getElementById('user_book_feeling_category_ids_0');
-    var feeling_category_select_element = this.$refs.user_book_feeling_category_ids_0;
-    console.log(this.$refs);
-    console.log(feeling_category_select_element);
-    console.log(feeling_category_element);
-    this.feelingCategories[0].innerHTML = feeling_category_element.innerHTML;
+    
+    for(let index=0; index < star_elements.length; index++) 
+    {
+      var star_value_element = document.getElementById('star_value'+ index);
+      this.feelingCategories.push({
+        innerHTML: feeling_category_element.innerHTML
+      })
+    };
   },
   methods: {
     setRating: function(rating){
@@ -46,12 +44,7 @@ export default {
       let refs = this.$refs
       this.star.rating.forEach(function(element,index){
         let property = "hidden_stars_"+index;
-        console.log(refs);
-        console.log(refs.hidden_stars_0);
-        console.log(property);
-        console.log(refs[property][0]);
         refs[property][0].value = element
-        console.log(element);
       });
     },
     addFeelingCategory () {

--- a/app/javascript/parts/stars.vue
+++ b/app/javascript/parts/stars.vue
@@ -1,11 +1,10 @@
 <template>
   <div>
-    <input type="hidden" ref="hidden_stars" name="user_book[user_feeling_category_stars]" id="user_book_user_feeling_category_stars">
     <div class="star-container" v-for="(feeling, index) in feelingCategories" :key="index" >
-      <select name="user_book[feeling_category_ids]" ref="user_book_feeling_category">
-        {{ feeling.innerHTML }}
+      <input type="hidden" :ref="'hidden_stars_'+index" name="user_book[user_feeling_category_stars]" :id="'user_book_user_feeling_category_stars_'+index">
+      <select v-html="feeling.innerHTML" name="user_book[feeling_category_ids]">
       </select>
-      <star-rating @rating-selected ="setRating" v-model="rating"></star-rating>
+      <star-rating @rating-selected ="setRating" v-model="star.rating[index]"></star-rating>
       <v-icon @click="addFeelingCategory" class="plus" large>mdi-plus-circle</v-icon>
     </div>
   </div>
@@ -16,7 +15,9 @@ export default {
   name: 'stars',
   data: function () {
     return {
-      rating: 0,
+      star: {
+        rating: []
+      },
       feelingCategories: [
         {
           innerHTML: ""
@@ -28,12 +29,12 @@ export default {
     var star_value_element = document.getElementById('star_value');
     var feeling_category_element = document.getElementById('user_book_feeling_category_ids');
     this.rating = parseInt(star_value_element.value);
-    this.$refs.hidden_stars.value = this.rating;
+    // this.$refs.hidden_stars.value = this.rating;
     feeling_category_element.hidden = true;
     // console.log(this.feelingCategoryRefs[0]);
     // this.feelingCategoryRefs[0].innerHTML = feeling_category_element.innerHTML;
     // var feeling_category_select_element = document.getElementById('user_book_feeling_category_ids_0');
-    var feeling_category_select_element = this.$refs.user_book_feeling_category_ids_0
+    var feeling_category_select_element = this.$refs.user_book_feeling_category_ids_0;
     console.log(this.$refs);
     console.log(feeling_category_select_element);
     console.log(feeling_category_element);
@@ -41,21 +42,23 @@ export default {
   },
   methods: {
     setRating: function(rating){
-      this.rating = rating;
-      this.$refs.hidden_stars.value = this.rating
-      console.log(3)
+      // this.$refs.hidden_stars_.value = this.rating
+      let refs = this.$refs
+      this.star.rating.forEach(function(element,index){
+        let property = "hidden_stars_"+index;
+        console.log(refs);
+        console.log(refs.hidden_stars_0);
+        console.log(property);
+        console.log(refs[property][0]);
+        refs[property][0].value = element
+        console.log(element);
+      });
     },
     addFeelingCategory () {
       let feeling_category_element = document.getElementById('user_book_feeling_category_ids');
       this.feelingCategories.push({
         innerHTML: feeling_category_element.innerHTML
       })
-      let refs = this.$refs;
-      this.feelingCategories.forEach(function(element, index){
-        console.log(refs.user_book_feeling_category[index]);
-        console.log(index);
-        refs.user_book_feeling_category[index].innerHTML = feeling_category_element.innerHTML;
-      });
     }
   },
 }

--- a/app/javascript/parts/stars.vue
+++ b/app/javascript/parts/stars.vue
@@ -1,16 +1,9 @@
 <template>
   <div>
     <input type="hidden" ref="hidden_stars" name="user_book[user_feeling_category_stars]" id="user_book_user_feeling_category_stars">
-    <div class="star-container" v-for="(feeling, index) in feelingCategories" :key="index">
-      <select name="user_book[feeling_category_ids]" id="user_book_feeling_category_ids"><option value="">選択して下さい</option>
-        <option value="100000">優しい</option>
-        <option value="100001">辛い</option>
-        <option value="100002">分かりやすい</option>
-        <option value="100003">ハラハラ</option>
-        <option value="100004">怖い</option>
-        <option value="100006"></option>
-        <option value="100007">えらい</option>
-        <option value="100008">すごい</option>
+    <div class="star-container" v-for="(feeling, index) in feelingCategories" :key="index" >
+      <select name="user_book[feeling_category_ids]" ref="user_book_feeling_category">
+        {{ feeling.innerHTML }}
       </select>
       <star-rating @rating-selected ="setRating" v-model="rating"></star-rating>
       <v-icon @click="addFeelingCategory" class="plus" large>mdi-plus-circle</v-icon>
@@ -25,14 +18,26 @@ export default {
     return {
       rating: 0,
       feelingCategories: [
-        {}
-      ]
+        {
+          innerHTML: ""
+        }
+      ],
     }
   },
   async mounted() {
-    var element = document.getElementById('star_value');
-    this.rating = parseInt(element.value);
-    this.$refs.hidden_stars.value = this.rating
+    var star_value_element = document.getElementById('star_value');
+    var feeling_category_element = document.getElementById('user_book_feeling_category_ids');
+    this.rating = parseInt(star_value_element.value);
+    this.$refs.hidden_stars.value = this.rating;
+    feeling_category_element.hidden = true;
+    // console.log(this.feelingCategoryRefs[0]);
+    // this.feelingCategoryRefs[0].innerHTML = feeling_category_element.innerHTML;
+    // var feeling_category_select_element = document.getElementById('user_book_feeling_category_ids_0');
+    var feeling_category_select_element = this.$refs.user_book_feeling_category_ids_0
+    console.log(this.$refs);
+    console.log(feeling_category_select_element);
+    console.log(feeling_category_element);
+    this.feelingCategories[0].innerHTML = feeling_category_element.innerHTML;
   },
   methods: {
     setRating: function(rating){
@@ -41,10 +46,18 @@ export default {
       console.log(3)
     },
     addFeelingCategory () {
+      let feeling_category_element = document.getElementById('user_book_feeling_category_ids');
       this.feelingCategories.push({
+        innerHTML: feeling_category_element.innerHTML
       })
-    },
-  }
+      let refs = this.$refs;
+      this.feelingCategories.forEach(function(element, index){
+        console.log(refs.user_book_feeling_category[index]);
+        console.log(index);
+        refs.user_book_feeling_category[index].innerHTML = feeling_category_element.innerHTML;
+      });
+    }
+  },
 }
 </script>
 

--- a/app/javascript/parts/stars.vue
+++ b/app/javascript/parts/stars.vue
@@ -18,33 +18,43 @@ export default {
       star: {
         rating: []
       },
-      feelingCategories: [
-        {
-          innerHTML: ""
-        }
-      ],
+      feelingCategories: []
     }
   },
   async mounted() {
-    let star_elements = document.getElementsByName('user_feeling_categories[stars]');
+    let default_star_elements = document.getElementsByName('user_feeling_categories[stars]');
     let feeling_category_element = document.getElementById('user_book_feeling_category_ids');
     feeling_category_element.hidden = true;
     
-    for(let index=0; index < star_elements.length; index++) 
+    for(let index=0; index<default_star_elements.length; index++) 
     {
-      var star_value_element = document.getElementById('star_value'+ index);
       this.feelingCategories.push({
         innerHTML: feeling_category_element.innerHTML
       })
     };
+    this.setRatingInit();
+    this.setAfterReadingInit();
   },
   methods: {
-    setRating: function(rating){
-      // this.$refs.hidden_stars_.value = this.rating
+    setRating: function(){
       let refs = this.$refs
       this.star.rating.forEach(function(element,index){
         let property = "hidden_stars_"+index;
         refs[property][0].value = element
+      });
+    },
+    setRatingInit: function(){
+      let default_star_elements = document.getElementsByName('user_feeling_categories[stars]');
+      let that = this
+      default_star_elements.forEach(function(element,index){
+        that.star.rating[index] = Number(element.value);
+      });
+    },
+    setAfterReadingInit: function(){
+      let default_after_reading_elements = document.getElementsByClassName('user_feeling_categories[feeling_after_readings]');
+      let that = this;
+      Array.prototype.forEach.call(default_after_reading_elements, function(element, index) {
+        that.feelingCategories[index].innerHTML = element.innerHTML;
       });
     },
     addFeelingCategory () {

--- a/app/javascript/parts/stars.vue
+++ b/app/javascript/parts/stars.vue
@@ -1,7 +1,20 @@
 <template>
   <div>
     <input type="hidden" ref="hidden_stars" name="user_book[user_feeling_category_stars]" id="user_book_user_feeling_category_stars">
-    <star-rating @rating-selected ="setRating" v-model="rating"></star-rating>
+    <div class="star-container" v-for="(feeling, index) in feelingCategories" :key="index">
+      <select name="user_book[feeling_category_ids]" id="user_book_feeling_category_ids"><option value="">選択して下さい</option>
+        <option value="100000">優しい</option>
+        <option value="100001">辛い</option>
+        <option value="100002">分かりやすい</option>
+        <option value="100003">ハラハラ</option>
+        <option value="100004">怖い</option>
+        <option value="100006"></option>
+        <option value="100007">えらい</option>
+        <option value="100008">すごい</option>
+      </select>
+      <star-rating @rating-selected ="setRating" v-model="rating"></star-rating>
+      <v-icon @click="addFeelingCategory" class="plus" large>mdi-plus-circle</v-icon>
+    </div>
   </div>
 </template>
 
@@ -11,20 +24,36 @@ export default {
   data: function () {
     return {
       rating: 0,
+      feelingCategories: [
+        {}
+      ]
     }
   },
   async mounted() {
     var element = document.getElementById('star_value');
     this.rating = parseInt(element.value);
+    this.$refs.hidden_stars.value = this.rating
   },
   methods: {
     setRating: function(rating){
       this.rating = rating;
       this.$refs.hidden_stars.value = this.rating
       console.log(3)
-    }
+    },
+    addFeelingCategory () {
+      this.feelingCategories.push({
+      })
+    },
   }
 }
 </script>
 
-
+<style>
+  .star-container {
+    display: flex;
+  }
+  
+  .plus {
+    margin-left: 20px;
+  }
+</style>

--- a/app/models/feeling_category.rb
+++ b/app/models/feeling_category.rb
@@ -1,4 +1,5 @@
 class FeelingCategory < ApplicationRecord
     has_many :user_feeling_categories
     has_many :user_books, through: :user_feeling_categories
+    validates :feeling_after_reading, presence: true
 end

--- a/app/views/user_books/edit.html.erb
+++ b/app/views/user_books/edit.html.erb
@@ -19,14 +19,29 @@
 
     <div>
         <label>読後感</label><br>
-        <%= f.collection_select :feeling_category_ids, FeelingCategory.all, :id, :feeling_after_reading, include_blank: "選択して下さい" %>
-        <%= hidden_field :user_feeling_categories, :stars, id: "star_value", value: @userBook.user_feeling_categories.first.stars %>
-        <div id="star_input"></div>
+        <div class="after-reading-container">
+            <%= f.collection_select :feeling_category_ids, FeelingCategory.where(user_id: @userBook.user_id).or(FeelingCategory.where(user_id: nil)).order(:user_id, :id), :id, :feeling_after_reading, include_blank: "選択して下さい" %>
+            <% if @userBook.user_feeling_categories.blank? %>
+                <%= hidden_field :user_feeling_categories, :stars, id: "star_value", value: 1 %>
+            <% else %>
+                <%= hidden_field :user_feeling_categories, :stars, id: "star_value", value: @userBook.user_feeling_categories&.first&.stars %>
+            <% end %>
+            <div id="star_input"></div>
+        </div>
     </div>
+    
+    <div>
+        <%= text_field :user_book, :feeling_after_reading %>
+    </div>
+    
     <div>
         <label>感想</label><br>
         <%= f.text_area :feeling %>
     </div>
     
     <div><%= f.submit "更新する" %></div>
+    
+    <div>
+        <%= link_to("戻る", user_books_path) %>
+    </div>
 <% end %>

--- a/app/views/user_books/edit.html.erb
+++ b/app/views/user_books/edit.html.erb
@@ -33,6 +33,8 @@
             <% end %>
             <% @userBook.user_feeling_categories.each_with_index do |user_feeling_category, index| %>
                 <%= hidden_field :user_feeling_categories, :stars, id: "star_value#{index}", value: user_feeling_category.stars %>
+                <%= f.collection_select :feeling_category_ids, FeelingCategory.where(user_id: @userBook.user_id).or(FeelingCategory.where(user_id: nil)).order(:user_id, :id), :id, :feeling_after_reading, 
+                    {include_blank: "選択して下さい",selected: user_feeling_category.feeling_category.id}, { id: "feeling_after_reading#{index}", class: "user_feeling_categories[feeling_after_readings]", style: "display:none;" } %>
             <% end %>
         </div>
     </div>

--- a/app/views/user_books/edit.html.erb
+++ b/app/views/user_books/edit.html.erb
@@ -4,6 +4,11 @@
 <span>現在ログイン中のユーザー：<%= current_user.name %></span>
 <%= form_for(@userBook, url: user_book_path(@userBook)) do |f| %>
     <div>
+        <% if @userBook.user_book_image.present? %>
+            <%= image_tag @userBook.user_book_image %>
+        <% end %>
+    </div>
+    <div>
         <label>タイトル</label><br>
         <%= f.text_field :title, autofocus: true %>
     </div>

--- a/app/views/user_books/edit.html.erb
+++ b/app/views/user_books/edit.html.erb
@@ -25,13 +25,15 @@
     <div>
         <label>読後感</label><br>
         <div class="after-reading-container">
-            <%= f.collection_select :feeling_category_ids, FeelingCategory.where(user_id: @userBook.user_id).or(FeelingCategory.where(user_id: nil)).order(:user_id, :id), :id, :feeling_after_reading, include_blank: "選択して下さい" %>
-            <% if @userBook.user_feeling_categories.blank? %>
-                <%= hidden_field :user_feeling_categories, :stars, id: "star_value", value: 1 %>
-            <% else %>
-                <%= hidden_field :user_feeling_categories, :stars, id: "star_value", value: @userBook.user_feeling_categories&.first&.stars %>
-            <% end %>
             <div id="star_input"></div>
+            <%= f.collection_select :feeling_category_ids, FeelingCategory.where(user_id: @userBook.user_id).or(FeelingCategory.where(user_id: nil)).order(:user_id, :id), :id, :feeling_after_reading, include_blank: "選択して下さい" %>
+
+            <% if @userBook.user_feeling_categories.empty? %>
+                <%= hidden_field :user_feeling_categories, :stars, id: "star_value", value: 1 %>
+            <% end %>
+            <% @userBook.user_feeling_categories.each_with_index do |user_feeling_category, index| %>
+                <%= hidden_field :user_feeling_categories, :stars, id: "star_value#{index}", value: user_feeling_category.stars %>
+            <% end %>
         </div>
     </div>
     

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root 'application#hello'
   resources :user_books
+  post '/user_books/:id' => "user_books#update"
 end

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -54,7 +54,7 @@ development:
   compile: true
 
   # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: true
+  check_yarn_integrity: false
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:

--- a/db/migrate/20210704160500_add_user_id_to_feeling_categories.rb
+++ b/db/migrate/20210704160500_add_user_id_to_feeling_categories.rb
@@ -1,0 +1,6 @@
+class AddUserIdToFeelingCategories < ActiveRecord::Migration[5.2]
+  def change
+    # 基本形: user_idという名前で users.id への外部キー制約をはる
+    add_reference :feeling_categories, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_30_074259) do
+ActiveRecord::Schema.define(version: 2021_07_04_160500) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -43,6 +43,8 @@ ActiveRecord::Schema.define(version: 2021_05_30_074259) do
     t.string "feeling_after_reading"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "user_id"
+    t.index ["user_id"], name: "index_feeling_categories_on_user_id"
   end
 
   create_table "user_books", force: :cascade do |t|
@@ -86,6 +88,7 @@ ActiveRecord::Schema.define(version: 2021_05_30_074259) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "feeling_categories", "users"
   add_foreign_key "user_books", "users"
   add_foreign_key "user_categories", "user_books"
   add_foreign_key "user_feeling_categories", "user_books"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1286,6 +1286,46 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "sass-loader": {
+          "version": "10.1.1",
+          "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.1.1.tgz",
+          "integrity": "sha512-W6gVDXAd5hR/WHsPicvZdjAWHBcEJ44UahgxcIE196fW2ong0ZHMPO1kZuI5q0VlvMQZh32gpv69PLWQm70qrw==",
+          "requires": {
+            "klona": "^2.0.4",
+            "loader-utils": "^2.0.0",
+            "neo-async": "^2.6.2",
+            "schema-utils": "^3.0.0",
+            "semver": "^7.3.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -3000,6 +3040,12 @@
         "regexp.prototype.flags": "^1.2.0"
       }
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
+    },
     "default-gateway": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
@@ -3109,6 +3155,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "dev": true
     },
     "detect-node": {
       "version": "2.1.0",
@@ -3635,6 +3687,15 @@
       "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"
+      }
+    },
+    "fibers": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
+      "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3"
       }
     },
     "figgy-pudding": {
@@ -6998,9 +7059,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.32.13",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.13.tgz",
-      "integrity": "sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==",
+      "version": "1.35.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.35.1.tgz",
+      "integrity": "sha512-oCisuQJstxMcacOPmxLNiLlj4cUyN2+8xJnG7VanRoh2GOLr9RqkvI4AxA4a6LHVg/rsu+PmxXeGhrdSF9jCiQ==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
       },
@@ -7028,18 +7089,18 @@
           }
         },
         "chokidar": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+          "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
           "requires": {
-            "anymatch": "~3.1.1",
+            "anymatch": "~3.1.2",
             "braces": "~3.0.2",
-            "fsevents": "~2.3.1",
-            "glob-parent": "~5.1.0",
+            "fsevents": "~2.3.2",
+            "glob-parent": "~5.1.2",
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
-            "readdirp": "~3.5.0"
+            "readdirp": "~3.6.0"
           }
         },
         "fill-range": {
@@ -7072,9 +7133,9 @@
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         },
         "readdirp": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-          "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+          "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
           "requires": {
             "picomatch": "^2.2.1"
           }
@@ -7090,45 +7151,13 @@
       }
     },
     "sass-loader": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.1.1.tgz",
-      "integrity": "sha512-W6gVDXAd5hR/WHsPicvZdjAWHBcEJ44UahgxcIE196fW2ong0ZHMPO1kZuI5q0VlvMQZh32gpv69PLWQm70qrw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.1.0.tgz",
+      "integrity": "sha512-FVJZ9kxVRYNZTIe2xhw93n3xJNYZADr+q69/s98l9nTCrWASo+DR2Ot0s5xTKQDDEosUkatsGeHxcH4QBp5bSg==",
+      "dev": true,
       "requires": {
         "klona": "^2.0.4",
-        "loader-utils": "^2.0.0",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.0.0",
-        "semver": "^7.3.2"
-      },
-      "dependencies": {
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
-        "schema-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
-          "requires": {
-            "@types/json-schema": "^7.0.6",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
+        "neo-async": "^2.6.2"
       }
     },
     "sax": {
@@ -8305,6 +8334,11 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
+    },
+    "vuetify": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.5.6.tgz",
+      "integrity": "sha512-2T8ML5PYuJ/AdMVH3ZIvzHnsM0nX8t4Xzj+0HFFGfLT7jLlptCFpG+JE8+kyrgGZlbUgulyOwCUu8hJkVsReFA=="
     },
     "watchpack": {
       "version": "1.7.5",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "book_recipe",
   "private": true,
   "dependencies": {
+    "@mdi/font": "^5.9.55",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
@@ -11,10 +12,15 @@
     "vue": "^2.6.12",
     "vue-loader": "^15.9.7",
     "vue-star-rating": "^1.7.0",
-    "vue-template-compiler": "^2.6.12"
+    "vue-template-compiler": "^2.6.12",
+    "vuetify": "^2.5.6"
   },
   "version": "0.1.0",
   "devDependencies": {
+    "deepmerge": "^4.2.2",
+    "fibers": "^5.0.0",
+    "sass": "^1.35.1",
+    "sass-loader": "^12.1.0",
     "webpack-dev-server": "^3.11.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -998,6 +998,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@mdi/font@^5.9.55":
+  version "5.9.55"
+  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.9.55.tgz#41acd50b88073ded7095fc3029d8712b6e12f38e"
+  integrity sha512-jswRF6q3eq8NWpWiqct6q+6Fg/I7nUhrxYJfiEM8JJpap0wVJLQdbKtyS65GdlK7S7Ytnx3TTi/bmw+tBhkGmg==
+
 "@npmcli/move-file@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.1.2.tgz#1a82c3e372f7cae9253eb66d72543d6b8685c674"
@@ -2495,6 +2500,11 @@ deep-equal@^1.0.1:
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 default-gateway@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-4.2.0.tgz#167104c7500c2115f6dd69b0a536bb8ed720552b"
@@ -2567,6 +2577,11 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
+
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-node@^2.0.4:
   version "2.0.5"
@@ -2948,6 +2963,13 @@ faye-websocket@^0.11.3:
   integrity sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==
   dependencies:
     websocket-driver ">=0.5.1"
+
+fibers@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fibers/-/fibers-5.0.0.tgz#3a60e0695b3ee5f6db94e62726716fa7a59acc41"
+  integrity sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==
+  dependencies:
+    detect-libc "^1.0.3"
 
 figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -5943,10 +5965,25 @@ sass-loader@10.1.1:
     schema-utils "^3.0.0"
     semver "^7.3.2"
 
+sass-loader@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-12.1.0.tgz#b73324622231009da6fba61ab76013256380d201"
+  integrity sha512-FVJZ9kxVRYNZTIe2xhw93n3xJNYZADr+q69/s98l9nTCrWASo+DR2Ot0s5xTKQDDEosUkatsGeHxcH4QBp5bSg==
+  dependencies:
+    klona "^2.0.4"
+    neo-async "^2.6.2"
+
 sass@^1.32.11:
   version "1.32.13"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.13.tgz#8d29c849e625a415bce71609c7cf95e15f74ed00"
   integrity sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+
+sass@^1.35.1:
+  version "1.35.1"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.35.1.tgz#90ecf774dfe68f07b6193077e3b42fb154b9e1cd"
+  integrity sha512-oCisuQJstxMcacOPmxLNiLlj4cUyN2+8xJnG7VanRoh2GOLr9RqkvI4AxA4a6LHVg/rsu+PmxXeGhrdSF9jCiQ==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 
@@ -6823,6 +6860,13 @@ vue-loader@^15.9.7:
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
 
+vue-star-rating@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/vue-star-rating/-/vue-star-rating-1.7.0.tgz#07576aa1a83d54d4e9ea80eebccf058ff3c868b6"
+  integrity sha512-2qdONqnIlvFzJoallfr7VuFRB6hBzYgBVEbXC3yYZz2TfMhx36WtYQ5p7JRjW+pzZx2PGQYZ75UFoBE0jwIANw==
+  dependencies:
+    vue "^2.3.3"
+
 vue-style-loader@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/vue-style-loader/-/vue-style-loader-4.1.3.tgz#6d55863a51fa757ab24e89d9371465072aa7bc35"
@@ -6844,10 +6888,20 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
+vue@^2.3.3:
+  version "2.6.14"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
+  integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==
+
 vue@^2.6.12:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
   integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
+
+vuetify@^2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-2.5.6.tgz#9cbb1eacece6c42028216312b9be23e35a7f5cf4"
+  integrity sha512-2T8ML5PYuJ/AdMVH3ZIvzHnsM0nX8t4Xzj+0HFFGfLT7jLlptCFpG+JE8+kyrgGZlbUgulyOwCUu8hJkVsReFA==
 
 watchpack-chokidar2@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
・読後感の選択登録機能で、読後感と星評価を紐づけて１セットとし、複数の読後感と星評価を選択登録できるようにした。
・読後感と星評価の選択登録後、再度編集ページを開いたとき、選択登録された読後感と星評価が表示されている状態になるようにした。
・利用者独自の読後感のカテゴリーを、新しく追加登録できるようにした。