### PR TITLE
Tabata/erase feeling category after reading

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -9,6 +9,7 @@ body {
       background-color: transparent;
       border-style: solid;
       padding: 1px 2px;
+      border-radius: 5px;
     }
   
     button, input, optgroup, select, textarea {
@@ -16,13 +17,9 @@ body {
     }
   
     input {
-        border-radius: 0;
+        border-radius: 5px;
     }
-  }
- 
-  .after-reading-container {
-    display: flex;
-  }
+}
 
 header {
   .navbar-transparent {
@@ -40,21 +37,6 @@ header {
   }
 }
 
-.btn-green {
-  font-family: Work Sans;
-  color: rgb(119, 110, 110);
-  border: 1px solid #fff;
-  padding-top: 15px;
-  padding-bottom: 15px;
-  font-size: 20px;
-  background-color: rgba(68, 192, 48, 0.6);
-  ;
-
-  &:hover {
-    color: #fff;
-  }
-}
-
 .top-hero-wrapper {
   width: 100vw;
   height: 100vh;
@@ -63,25 +45,96 @@ header {
   background-repeat: no-repeat;
   background-attachment: fixed;
   background-size: cover;
-  background-color: #292828;
+
+  .text-white {
+    color: #FBFDE4;
+    text-shadow: 1px 1px 0 #8e8f7e,
+                 -1px 1px 0 #8e8f7e,
+                 1px -1px 0 #8e8f7e,
+                 -1px -1px 0 #8e8f7e;
+  }
+
+  .btn-green {
+    font-family: Work Sans;
+    color: rgb(119, 110, 110);
+    border: 1px solid #fff;
+    padding-top: 15px;
+    padding-bottom: 15px;
+    font-size: 20px;
+    background-color: rgba(68, 192, 48, 0.6);
+  
+    &:hover {
+      color: #fff;
+    }
+  }
+
+  .top-hero-container {
+    padding-top: 220px;
+    h1 {
+      font-size: 80px;
+      line-height: 1;
+      font-family: 'Bitter', serif;
+      color: rgba(68, 192, 48, 0.8);
+      margin-bottom: 50px;
+      text-shadow: 1px 1px 1px rgba(54, 163, 37, 0.9);
+    }
+    h3 {
+      margin-bottom: 60px;
+    }
+  }
 }
 
-.top-hero-container h1{
-  font-size: 80px;
-  line-height: 1;
-  font-family: 'Bitter', serif;
-  color: rgba(68, 192, 48, 0.8);;
-}
-
-.text-white {
-  color: #FBFDE4;
-}
 
 .hidden {
   display: none;
 }
 
-.user-book-index-single img{
-  float: left;
-  margin: 0 10px 10px 0;
+.user-books-index {
+  .user-book-index-single img {
+    float: left;
+    margin: 0 10px 10px 0;
+  }
+  .user-book-index-single {
+    background-color: #FBFDE4;
+    border-radius: 5px;
+  }
+
+  .feeling_category {
+    clear: left;
+  }
+  
+  .btn-default {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 14px;
+    color: #fff;
+    width: 120px;
+    height: 40px;
+    line-height: 28px;
+    align-items: center;
+    text-align: center;
+    letter-spacing: 0.4em
+  }
+
+  .edit {
+    background-color: rgba(68, 192, 48, 0.62);
+    
+    &:hover {
+      background-color: rgba(68, 192, 48, 0.8);
+    }
+  }    
+
+  .delete {
+    background-color: rgba(46, 115, 131, 0.65);
+
+    &:hover {
+      background-color: rgba(46, 115, 131, 0.8);
+    }
+  }
 }
+
+.user-book-edit-wrapper {
+  .after-reading-container {
+    display: flex;
+  }
+}
+

--- a/app/controllers/user_books_controller.rb
+++ b/app/controllers/user_books_controller.rb
@@ -14,8 +14,8 @@ class UserBooksController < ApplicationController
     @userBooks = UserBook.search(params[:keyword],params[:category_ids],params[:feeling_category_ids],params[:stars], current_user)
     @keyword = params[:keyword]
     @category_ids = params[:category_ids]
-    @feeling_category_ids = params[:feeling_category_ids]
-    @stars = params[:stars]
+    @feeling_category_ids = params[:feeling_category_ids] ||= []
+    @stars = params[:stars] ||= []
     render "index"
   end
   

--- a/app/javascript/packs/feeling_index_vue.js
+++ b/app/javascript/packs/feeling_index_vue.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import feelingIndex from '../parts/feeling_index.vue';
+import FeelingIndex from '../parts/feeling_index.vue';
 import StarRating from 'vue-star-rating';
 import Vuetify from 'vuetify';
 import 'vuetify/dist/vuetify.min.css';
@@ -11,15 +11,18 @@ const vuetify = new Vuetify(); // 追加
 Vue.component('star-rating', StarRating);
 
 document.addEventListener('DOMContentLoaded', () => {
-  const feelingStarsIndex = new Vue({
-    vuetify,
-    render: h => h(feelingIndex)
-  }).$mount()
   var elements = document.getElementsByClassName('feeling_after');
   for(var i = 0; i < elements.length; i++){
-    var $ele_clone = $(feelingStarsIndex.$el).clone();
-    elements[i].append($ele_clone);
-    console.log(i);
-    console.log(feelingStarsIndex.$el);
+    console.log(elements[i].dataset.stars);
+    console.log(elements[i].dataset.feelingCategoryId);
+    const feelingStarsIndex = new Vue({
+      vuetify,
+      render: h => h(FeelingIndex, 
+      { props: { prop_stars: elements[i].dataset.stars,
+                 prop_feeling_category_id: elements[i].dataset.feelingCategoryId,
+                 prop_feeling_after_reading: elements[i].dataset.feelingAfterReading }
+      })
+    }).$mount()
+    elements[i].append(feelingStarsIndex.$el);
   };
 });

--- a/app/javascript/packs/feeling_index_vue.js
+++ b/app/javascript/packs/feeling_index_vue.js
@@ -1,0 +1,25 @@
+import Vue from 'vue';
+import feelingIndex from '../parts/feeling_index.vue';
+import StarRating from 'vue-star-rating';
+import Vuetify from 'vuetify';
+import 'vuetify/dist/vuetify.min.css';
+import '@mdi/font/css/materialdesignicons.css'
+
+Vue.use(Vuetify); // 追加
+const vuetify = new Vuetify(); // 追加
+
+Vue.component('star-rating', StarRating);
+
+document.addEventListener('DOMContentLoaded', () => {
+  const feelingStarsIndex = new Vue({
+    vuetify,
+    render: h => h(feelingIndex)
+  }).$mount()
+  var elements = document.getElementsByClassName('feeling_after');
+  for(var i = 0; i < elements.length; i++){
+    var $ele_clone = $(feelingStarsIndex.$el).clone();
+    elements[i].append($ele_clone);
+    console.log(i);
+    console.log(feelingStarsIndex.$el);
+  };
+});

--- a/app/javascript/parts/book_list.vue
+++ b/app/javascript/parts/book_list.vue
@@ -64,6 +64,7 @@ export default {
       return items;
     },
     changeBooks: async function(){
+      // data内のsearchとresults
       var value = this.search;
       if (value == ''){
         this.results = ''

--- a/app/javascript/parts/book_list.vue
+++ b/app/javascript/parts/book_list.vue
@@ -1,22 +1,27 @@
 <template>
   <div class="user-book-new-wrapper">
     <div class="container">
-      <h2>本の新規登録</h2>
-      <input v-model="search" class='input bg-white mb16' type='search' @input="changeBooks" placeholder="本のタイトル・著者名">
-      
-      <div class="user-book-new-search">
-        <h2 class='mb8'>検索結果</h2>
-        <div id='$results' v-for="(result, index) in results">
-          <a class='f border bg-white mb8' :href="result.link" target='_blank'>
-            {{ result.title }}
-          </a>
-          <input :id="'title' + index" type='hidden' :value="result.title" name="title">
-          <img :id="'image'+ index" class='w100 object-fit-contain bg-gray' :src="result.image">
-          <div v-for="author in result.authors">
-            {{ author }}
+      <div class="row">
+        <div class="user-book-new-reserve col-md-6 col-md-offset-3">
+          <div class="new-search-form">
+            <h2>本の新規登録</h2>
+            <input v-model="search" class='input bg-white mb16' type='search' @input="changeBooks" placeholder="本のタイトル・著者名">
           </div>
-          <input :id="'author' + index" type="hidden" :value="result.authors" name="author">
-          <button type="button" @click="createBook(index)">登録する</button>
+          <div class="new-search-result">
+            <h2 class='mb8'>検索結果</h2>
+            <div id='$results' v-for="(result, index) in results">
+              <a class='f border bg-white mb8' :href="result.link" target='_blank'>
+                {{ result.title }}
+              </a>
+              <input :id="'title' + index" type='hidden' :value="result.title" name="title">
+              <img :id="'image'+ index" class='w100 object-fit-contain bg-gray' :src="result.image">
+              <div v-for="author in result.authors">
+                {{ author }}
+              </div>
+              <input :id="'author' + index" type="hidden" :value="result.authors" name="author">
+              <button type="button" @click="createBook(index)">登録する</button>
+            </div> 
+          </div>
         </div>
       </div>
     </div>

--- a/app/javascript/parts/feeling_index.vue
+++ b/app/javascript/parts/feeling_index.vue
@@ -1,48 +1,40 @@
 <template>
   <div>
-    <div class="star-container" v-for="(feeling, index) in feelingCategories" :key="index" >
-      <!-- setRatingから送られてきた星の数のデータを受け取って、railsに送信する体裁を整えている -->
-      <input type="hidden" :ref="'hidden_stars_'+index" name="user_book[user_feeling_category_star][]" :id="'user_book_user_feeling_category_stars_'+index">
-      <select v-html="feeling.innerHTML" name="user_book[feeling_category_id][]">
-      </select>
+    <div class="feeling-index-container" v-for="(feeling, index) in feelingCategories" :key="index" >
       <star-rating @rating-selected ="setRating" v-model="star.rating[index]"></star-rating>
-      <v-icon @click="addFeelingCategory" class="plus" large>mdi-plus-circle</v-icon>
-      <!-- feelingが複数表示されている時のみ、消去ボタンを表示 -->
-      <v-icon v-if="index !== 0" @click="deleteFeelingCategory(index)" class="minus" large>mdi-minus-circle</v-icon>
     </div>
   </div>
 </template>
 
 <script>
 export default {
-  name: 'stars',
+  name: 'feelingStars',
   data: function () {
     return {
       // 星の数のデータ
       star: {
         rating: []
       },
-      // 読後感のフォーマット情報とデータ
       feelingCategories: []
     }
   },
   async mounted() {
-    // 登録されている星の数のデータを取得
-    let default_star_elements = document.getElementsByName('user_feeling_categories[stars]');
-    // railsで作った読後感のフォーマットを取得
-    let feeling_category_element = document.getElementById('user_book_feeling_category_ids');
-    feeling_category_element.hidden = true;
-    console.log(default_star_elements)
-    // 登録されている星データのセット数分、読後感のフォーマットHTMLをそのままvueに入れている。
+    // 登録されている星
+    let default_star_elements = document.getElementsByClassName("feeling_stars[]");
+    // 読後感
+    let feeling_category_elements = document.getElementsByClassName('feeling_reading[]');
+    feeling_category_elements.hidden = true;
+
+    console.log(feeling_category_elements.textContent);
     for(let index=0; index<default_star_elements.length; index++) 
     {
       this.feelingCategories.push({
-        innerHTML: feeling_category_element.innerHTML
+        innerHTML: feeling_category_elements.innerHTML
       })
     };
+    console.log(this.feelingCategories);
     this.setRatingInit();
     this.setAfterReadingInit();
-    console.log(this.feelingCategories);
   },
   updated() {
     this.setRating()

--- a/app/javascript/parts/feeling_index.vue
+++ b/app/javascript/parts/feeling_index.vue
@@ -1,92 +1,50 @@
 <template>
-  <div>
-    <div class="feeling-index-container" v-for="(feeling, index) in feelingCategories" :key="index" >
-      <star-rating @rating-selected ="setRating" v-model="star.rating[index]"></star-rating>
-    </div>
+  <div class="star-container">
+    {{feelingAfterReading}}
+    <star-rating :read-only="true" :rating = "stars" :star-size=40 :padding=10></star-rating>
   </div>
 </template>
 
 <script>
+import axios from 'axios';
+
 export default {
-  name: 'feelingStars',
+  name: 'simple',
+  props: {
+      prop_stars: String,
+      prop_feeling_category_id: String,
+      prop_feeling_after_reading: String
+    },
   data: function () {
     return {
       // 星の数のデータ
-      star: {
-        rating: []
-      },
-      feelingCategories: []
-    }
+      stars: 0,
+      feelingCategoryId: [],
+      feelingCategories: [],
+      feelingAfterReading: ''
+      }
   },
-  async mounted() {
-    // 登録されている星
-    let default_star_elements = document.getElementsByClassName("feeling_stars[]");
-    // 読後感
-    let feeling_category_elements = document.getElementsByClassName('feeling_reading[]');
-    feeling_category_elements.hidden = true;
+  mounted() {
+    axios
+      //GETリクエストでRailsで作成したjsonを取得する
+      .get('/api/v1/feeling_categories.json')
+      //response.data は RailsのUser.select(:id, :name, :email)
+      //これをdata()で定義したusersに代入する
+      .then(response => (this.feelingCategories = response.data))
 
-    console.log(feeling_category_elements.textContent);
-    for(let index=0; index<default_star_elements.length; index++) 
-    {
-      this.feelingCategories.push({
-        innerHTML: feeling_category_elements.innerHTML
-      })
-    };
-    console.log(this.feelingCategories);
-    this.setRatingInit();
-    this.setAfterReadingInit();
-  },
-  updated() {
-    this.setRating()
-  },
-  methods: {
-    setRating: function(){
-      let refs = this.$refs
-      // 星の数が変更・クリックされた時に、dataのstar.ratingに入ってきた数値を、ref対応しているinputに渡している。
-      this.star.rating.forEach(function(element,index){
-        let property = "hidden_stars_"+index;
-        console.log(property)
-        refs[property][0].value = element
-      });
-    },
-    setRatingInit: function(){
-      // 既に登録されている星の数のデータを渡している。
-      let default_star_elements = document.getElementsByName('user_feeling_categories[stars]');
-      let that = this
-      default_star_elements.forEach(function(element,index){
-        that.star.rating[index] = Number(element.value);
-      });
-    },
-    setAfterReadingInit: function(){
-      // 既に登録されている読後感のフォーマットとデータを渡している。
-      let default_after_reading_elements = document.getElementsByClassName('user_feeling_categories[feeling_after_readings]');
-      let that = this;
-      Array.prototype.forEach.call(default_after_reading_elements, function(element, index) {
-        that.feelingCategories[index].innerHTML = element.innerHTML;
-      });
-    },
-    addFeelingCategory () {
-      let feeling_category_element = document.getElementById('user_book_feeling_category_ids');
-      this.feelingCategories.push({
-        innerHTML: feeling_category_element.innerHTML
-      })
-    },
-    deleteFeelingCategory(index) {
-      // 星をクリックすると、setRatingが走り、星の数のデータが変更されて渡される。変更された星の数のデータも削除する。
-      this.star.rating.splice(index, 1);
-      // 指定されたindexの要素を1つ削除します。
-      this.feelingCategories.splice(index, 1)
-    }
-  },
+    console.log(this.prop_stars);
+    this.stars = Number(this.prop_stars)
+    console.log(this.stars);
+    console.log(this.prop_feeling_category_id);
+    this.feelingCategoryId = Number(this.prop_feeling_category_id);
+    console.log(this.feelingCategoryId);
+    this.feelingAfterReading = this.prop_feeling_after_reading;
+  }
 }
 </script>
 
 <style>
   .star-container {
     display: flex;
-  }
-  
-  .plus {
-    margin-left: 20px;
   }
 </style>

--- a/app/javascript/parts/feeling_search.vue
+++ b/app/javascript/parts/feeling_search.vue
@@ -2,14 +2,14 @@
   <div>
     <div v-for="(feeling, index) in feelingCategoryIds" :key="index" >
       <select v-model="feelingCategoryIds[index]" name="feeling_category_ids[]">
-        <option value="" >読後感を選択して下さい</option>
+        <option value="">読後感</option>
         <option v-for="feelingCategory in feelingCategories" :key="feelingCategory.id" :value="feelingCategory.id">
           {{feelingCategory.feeling_after_reading}}
         </option>
       </select>
       が
       <select v-model="stars[index]" name="stars[]">
-        <option value="">選択してください</option>
+        <option value="">☆の数を選択してください</option>
         <option value="stars_5">☆５のみ</option>
         <option value="stars_4">☆４のみ</option>
         <option value="stars_3">☆３のみ</option>
@@ -19,6 +19,8 @@
         <option value="stars_low">低評価（☆２以下）</option>
       </select>
       <span><v-icon @click="addFeelingCategory" class="plus" large color="green accent-3">mdi-plus-circle</v-icon></span>
+      <v-icon v-if="index !== 0" @click="deleteFeelingCategory(index)" class="minus" large>mdi-minus-circle</v-icon>
+
     </div>
   </div>
 </template>
@@ -30,9 +32,9 @@ export default {
   name: 'feeling_stars',
   data: function () {
     return {
-      // feeling_categories_controllerで取得したjsonデータ
+      // feeling_categories_controllerで取得した登録されている読後感全てのjsonデータ
       feelingCategories: [],
-      // railsで取得したデフォルトのデータ
+      // railsで選択されたデータ
       feelingCategoryIds: [],
       stars: []
     }
@@ -50,6 +52,7 @@ export default {
     let feeling_category_element = document.getElementById('feeling_search');
     feeling_category_element.hidden = true;
 
+    // 取得した読後感と星の数値をvueに渡している
     for(let index=0; index<default_feeling_elements.length; index++) 
     {
       this.feelingCategoryIds.push(default_feeling_elements[index].value)
@@ -59,6 +62,10 @@ export default {
   methods: {
     addFeelingCategory () {
       this.feelingCategoryIds.push({ })
+    },
+    deleteFeelingCategory(index) {
+      // 指定されたindexの要素を1つ削除します。
+      this.feelingCategoryIds.splice(index, 1)
     }
   },
 }

--- a/app/javascript/parts/stars.vue
+++ b/app/javascript/parts/stars.vue
@@ -5,7 +5,7 @@
       <input type="hidden" :ref="'hidden_stars_'+index" name="user_book[user_feeling_category_star][]" :id="'user_book_user_feeling_category_stars_'+index">
       <select v-html="feeling.innerHTML" name="user_book[feeling_category_id][]">
       </select>
-      <star-rating @rating-selected ="setRating" v-model="star.rating[index]"></star-rating>
+      <star-rating @rating-selected ="setRating" v-model="star.rating[index]" :star-size=40 :padding=10></star-rating>
       <v-icon @click="addFeelingCategory" class="plus" large>mdi-plus-circle</v-icon>
       <!-- feelingが複数表示されている時のみ、消去ボタンを表示 -->
       <v-icon v-if="index !== 0" @click="deleteFeelingCategory(index)" class="minus" large>mdi-minus-circle</v-icon>

--- a/app/models/user_book.rb
+++ b/app/models/user_book.rb
@@ -5,9 +5,8 @@ class UserBook < ApplicationRecord
   has_many :categories, through: :user_categories
   has_many :user_feeling_categories, dependent: :destroy
   has_many :feeling_categories, through: :user_feeling_categories
-  
+
   def self.search(keyword, category_ids, feeling_category_ids, stars, current_user)
-    # 後日、見直した！スッキリ！
     query = self.order(id: 'DESC')
     query = query.where(["(title like ? OR author like ?)", "%#{keyword}%", "%#{keyword}%"]) if keyword.present?
     query = query.left_joins(:categories).where(["categories.id = ?", category_ids]) if category_ids.present?

--- a/app/models/user_book.rb
+++ b/app/models/user_book.rb
@@ -11,7 +11,7 @@ class UserBook < ApplicationRecord
     query = query.where(["(title like ? OR author like ?)", "%#{keyword}%", "%#{keyword}%"]) if keyword.present?
     query = query.left_joins(:categories).where(["categories.id = ?", category_ids]) if category_ids.present?
     user_book_ids = UserBook.where(user_id: current_user.id).pluck(:id)
-    if feeling_category_ids.present?
+    if feeling_category_ids&.first&.present?
       feeling_category_ids.each_with_index do |feeling_category_id, index|
         feeling_category_query = query.left_joins(:feeling_categories).where(["feeling_categories.id = ?", feeling_category_id]) 
         if stars[index] == "stars_5"

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -1,6 +1,6 @@
 <div class="top-hero-wrapper">
   <div class="container top-hero-container">
-    <h1 class="text-white">Enjoy your reading life!</h1>
+    <h1 class="text-green">Enjoy your reading life!</h1>
     <h3 class="text-white">このアプリは本の読後感を、記録・検索できます。</h3>
     <h3 class="text-white">まるで処方箋のように、その時の気分に寄り添った読後感の本を選び、読み返すことができます。</h3>
     <br><h3 class="text-white">ぜひ、自分だけの『本の処方箋』を作って、読書生活を楽しみましょう！</h3>
@@ -11,11 +11,9 @@
           <%= link_to 'Log in', new_user_session_url, class: 'btn btn-block btn-green' %>
         </div>
         <div class="col-md-3">
-          <%= link_to 'Sign up', new_user_registration_url, class: 'btn btn-block btn-green'%>
+          <%= link_to 'Sign up', new_user_registration_url, class: 'btn btn-block btn-green' %>
         </div>    
       </div>
     <% end %>
   </div>
-
-  
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,35 +16,35 @@
 
   <body>
     <header>
+    <% if user_signed_in? %>
       <nav class="navbar navbar-default navbar-transparent">
         <div class="container">
           <%= link_to root_path do %>
             <span><%= image_tag 'logo2-3.png', class:"logo" %></span>
           <% end %>
-          <ul class="nav navbar-nav navbar-right">
-            <% if user_signed_in? %>
-              <li>
-                <p><%= current_user.name %></p>
-              </li>
-              <li>
-                <%= link_to '登録した本の一覧・検索', user_books_path, data: {"turbolinks"=>false} %>
-              </li>
-              <li>
-                <%= link_to '本の新規登録', new_user_book_path, data: {"turbolinks"=>false} %>
-              </li>
-              <li>
-                <%= link_to 'カテゴリーの追加・編集', categories_index_url %>
-              </li>
-              <li>
-                <%= link_to '読後感の追加・編集', feeling_categories_index_url %>
-              </li>
-              <li>
-                <%= link_to 'ログアウト', destroy_user_session_url, method: :delete %>
-              </li>
-            <% end %>
+          <ul class="nav navbar-nav navbar-right">           
+            <li>
+              <p><%= current_user.name %></p>
+            </li>
+            <li>
+              <%= link_to '登録した本の一覧・検索', user_books_path, data: {"turbolinks"=>false} %>
+            </li>
+            <li>
+              <%= link_to '本の新規登録', new_user_book_path, data: {"turbolinks"=>false} %>
+            </li>
+            <li>
+              <%= link_to 'カテゴリーの編集', categories_index_url %>
+            </li>
+            <li>
+              <%= link_to '読後感の編集', feeling_categories_index_url %>
+            </li>
+            <li>
+              <%= link_to 'ログアウト', destroy_user_session_url, method: :delete %>
+            </li>  
           </ul>
         </div>
       </nav>
+    <% end %>
     </header>
     <%= yield %>
   </body>

--- a/app/views/user_books/edit.html.erb
+++ b/app/views/user_books/edit.html.erb
@@ -25,11 +25,13 @@
                 <label>読後感</label><br>
                 <div class="after-reading-container">
                     <div id="star_input"></div>
+                    <%# 読後感フォーマット。id名は'user_book_feeling_category_ids'に変換される。%>
                     <%= f.collection_select :feeling_category_ids, FeelingCategory.where(user_id: @userBook.user_id).or(FeelingCategory.where(user_id: nil)).order(:user_id, :id), :id, :feeling_after_reading, include_blank: "選択して下さい" %>
 
                     <% if @userBook.user_feeling_categories.empty? %>
                         <%= hidden_field :user_feeling_categories, :stars, id: "star_value", value: 1 %>
                     <% end %>
+                    <%# 既に複数登録されていたデータがあった時や、登録情報を変更される時に使用。starsのid名は'user_feeling_categories[stars]'に変換される。%>
                     <% @userBook.user_feeling_categories.each_with_index do |user_feeling_category, index| %>
                         <%= hidden_field :user_feeling_categories, :stars, id: "star_value#{index}", value: user_feeling_category.stars %>
                         <%= f.collection_select :feeling_category_ids, FeelingCategory.where(user_id: @userBook.user_id).or(FeelingCategory.where(user_id: nil)).order(:user_id, :id), :id, :feeling_after_reading, 

--- a/app/views/user_books/index.html.erb
+++ b/app/views/user_books/index.html.erb
@@ -1,4 +1,5 @@
 <%= javascript_pack_tag 'feeling_stars_search_vue' %>
+<%= javascript_pack_tag 'feeling_index_vue' %>
 
 <div class="user-books-index-wrapper">
   <div class="user-book-search container">
@@ -40,11 +41,27 @@
                 <div class="user-book-show">
                   <h3><%= userBook.title %></h3>
                   <p><%= userBook.author %></p>
+                  <div class="category">
+                    <% userBook.categories.each do |category| %>
+                      <button type="button" class="btn btn-success"><%= category.category_name %></button>
+                    <% end %>
+                  </div>
                   <br>
+                  <div class="feeling_category">
+                    <label>読後感</label>
+                    <% userBook.feeling_categories.each_with_index do |feeling_category, index| %>
+                      <p class="feeling_reading[]" id="feeling_after_<%= index %>"><%= feeling_category.feeling_after_reading %></p>
+                    <% end %>
+                    <% userBook.user_feeling_categories.each_with_index do |user_feeling_category, index| %>
+                      <p class="feeling_stars[]" id="feeling_stars_<%= index %>"><%= user_feeling_category.stars %></p>
+                    <% end %>
+                  </div>
+                  <div class="feeling_after"></div>
                   <p><%= userBook.feeling %></p>
                 </div>
-                <%= link_to "編集", edit_user_book_path(userBook), "data-turbolinks": false %>
-                <%= link_to "削除", userBook, method: :delete, data: { confirm: "削除してもよろしいですか？" } %>
+                <feeling-stars></feeling-stars>
+                <%= link_to "編集", edit_user_book_path(userBook), "data-turbolinks": false, class: "btn btn-default edit" %>
+                <%= link_to "削除", userBook, method: :delete, data: { confirm: "削除してもよろしいですか？"},  class: "btn btn-default delete" %>
               </div>
             </div>
         <% end %>

--- a/app/views/user_books/index.html.erb
+++ b/app/views/user_books/index.html.erb
@@ -43,20 +43,17 @@
                   <p><%= userBook.author %></p>
                   <div class="category">
                     <% userBook.categories.each do |category| %>
-                      <button type="button" class="btn btn-success"><%= category.category_name %></button>
+                      <%= link_to category.category_name, search_path(category_ids: category.id), class:"btn btn-success" %>
                     <% end %>
                   </div>
                   <br>
                   <div class="feeling_category">
                     <label>読後感</label>
-                    <% userBook.feeling_categories.each_with_index do |feeling_category, index| %>
-                      <p class="feeling_reading[]" id="feeling_after_<%= index %>"><%= feeling_category.feeling_after_reading %></p>
-                    <% end %>
                     <% userBook.user_feeling_categories.each_with_index do |user_feeling_category, index| %>
-                      <p class="feeling_stars[]" id="feeling_stars_<%= index %>"><%= user_feeling_category.stars %></p>
+                      <div class="feeling_after" data-stars="<%= user_feeling_category.stars %>" 
+                        data-feeling-category-id="<%= user_feeling_category.feeling_category_id %>" data-feeling-after-reading="<%= user_feeling_category.feeling_category.feeling_after_reading %>" ></div>
                     <% end %>
                   </div>
-                  <div class="feeling_after"></div>
                   <p><%= userBook.feeling %></p>
                 </div>
                 <feeling-stars></feeling-stars>


### PR DESCRIPTION
・編集画面で、読後感カテゴリーと星評価のフォームが複数あった時、アイコンを押すことで減らせるようにした。
・検索画面で、読後感カテゴリーと星評価のフォームが複数あった時、アイコンを押すことで減らせるようにした。

・登録した本の一覧画面で、vueを使って、読後感と星評価を一覧表示できるようにした。

・検索フォームのカテゴリーのみを指定して検索をかけた時に、該当するデータがあるにも関わらず、検索できなかったバグの修正

・登録した本の一覧画面で、それぞれの本の情報に表示されているカテゴリーボタンを押すことでも、同カテゴリーの検索をすることができるようにした。