### PR TITLE
本の編集画面で読後感が空のまま更新された時のエラーの修正

### DIFF
--- a/app/controllers/user_books_controller.rb
+++ b/app/controllers/user_books_controller.rb
@@ -63,6 +63,7 @@ class UserBooksController < ApplicationController
     if user_book_update_params[:feeling_category_id].present?
       @userBook.user_feeling_categories.destroy_all
       user_book_update_params[:feeling_category_id].each_with_index do |feeling_category_id, index|
+        next if feeling_category_id.blank?
         @userFeelingCategory = UserFeelingCategory.new(
           user_book_id: @userBook.id
         )

--- a/app/javascript/parts/stars.vue
+++ b/app/javascript/parts/stars.vue
@@ -3,7 +3,7 @@
     <div class="star-container" v-for="(feeling, index) in feelingCategories" :key="index" >
       <!-- setRatingから送られてきた星の数のデータを受け取って、railsに送信する体裁を整えている -->
       <input type="hidden" :ref="'hidden_stars_'+index" name="user_book[user_feeling_category_star][]" :id="'user_book_user_feeling_category_stars_'+index">
-      <select v-html="feeling.innerHTML" name="user_book[feeling_category_id][]">
+      <select v-html="feeling.innerHTML" required name="user_book[feeling_category_id][]">
       </select>
       <star-rating @rating-selected ="setRating" v-model="star.rating[index]" :star-size=40 :padding=10></star-rating>
       <v-icon @click="addFeelingCategory" class="plus" large>mdi-plus-circle</v-icon>


### PR DESCRIPTION
・本の編集画面で読後感が空のままで更新ボタンが押された時、フロント側からは必須項目の注意メッセージが出るようにして、バックエンド側からは更新の処理が通らないようにした。