### PR TITLE
ユーザー所有データのアクセス制御を強化

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,18 +1,17 @@
 class CategoriesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_category, only: [:edit, :destroy]
+
   def index
     @defaultCategories = Category.where(user_id: nil)
     @categories = Category.where(user_id: current_user.id).order(:user_id, :id)
   end
   
   def edit
-    @category = Category.find(params[:id])
   end
   
   def update
-    @category = Category.find_or_initialize_by(
-      id: categories_params[:category_id],
-      user_id: current_user.id,
-      )
+    @category = Category.find_by!(id: categories_params[:category_id], user_id: current_user.id)
     @category.category_name = categories_params[:category_name]
     @category.save!
     redirect_to categories_index_url
@@ -28,14 +27,16 @@ class CategoriesController < ApplicationController
   end
   
   def destroy
-    @category = Category.find(params[:id])
-    if  @category.user_id == current_user.id
-      @category.destroy
-      redirect_to categories_index_url
-    end
+    @category.destroy
+    redirect_to categories_index_url
   end
   
   private
+
+  def set_category
+    @category = Category.find_by!(id: params[:id], user_id: current_user.id)
+  end
+
   def categories_params
     params.permit(:category_name, :category_id)
   end

--- a/app/controllers/feeling_categories_controller.rb
+++ b/app/controllers/feeling_categories_controller.rb
@@ -1,16 +1,18 @@
 class FeelingCategoriesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_feeling_category, only: [:edit, :destroy]
+
   def index
     @defaultFeelingCategories = FeelingCategory.where(user_id: nil)
     @feelingCategories = FeelingCategory.where(user_id: current_user.id).order(:user_id, :id)
   end
   
   def edit
-    @feelingCategory = FeelingCategory.find(params[:id])
   end
   
   def update
     if feeling_category_params[:feeling_after_reading].present?
-      @feelingCategory = FeelingCategory.find_or_initialize_by(
+      @feelingCategory = FeelingCategory.find_by!(
         id: feeling_category_params[:feeling_category_id],
         user_id: current_user.id
       )
@@ -30,15 +32,16 @@ class FeelingCategoriesController < ApplicationController
   end
   
   def destroy
-    @feelingCategory = FeelingCategory.find_by(
-      id: params[:id], 
-      user_id: current_user.id
-    )
     @feelingCategory.destroy
     redirect_to feeling_categories_index_url
   end
   
   private
+
+  def set_feeling_category
+    @feelingCategory = FeelingCategory.find_by!(id: params[:id], user_id: current_user.id)
+  end
+
   def feeling_category_params
     params.permit(:feeling_after_reading, :feeling_category_id)
   end

--- a/app/controllers/user_books_controller.rb
+++ b/app/controllers/user_books_controller.rb
@@ -3,6 +3,7 @@ class UserBooksController < ApplicationController
   require 'uri'
   before_action :authenticate_user!
   before_action :set_user_book, only: [:edit, :show, :destroy, :update]
+  before_action :set_category_options, only: [:index, :edit, :search]
   
   def index
     @userBooks = UserBook.where(user_id: current_user.id).order(id: 'DESC')
@@ -108,7 +109,11 @@ class UserBooksController < ApplicationController
   end
     
   def set_user_book
-    @userBook = UserBook.find(params[:id]) 
+    @userBook = current_user.user_books.find(params[:id]) 
+  end
+
+  def set_category_options
+    @category_options = Category.where(user_id: [nil, current_user.id]).order(:user_id, :id)
   end
   
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,5 +3,9 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_many :user_books, dependent: :destroy
+  has_many :categories, dependent: :destroy
+  has_many :feeling_categories, dependent: :destroy
+
   validates :name, presence: true
 end

--- a/app/views/user_books/edit.html.erb
+++ b/app/views/user_books/edit.html.erb
@@ -18,7 +18,7 @@
             
             <div class="category">
                 <label>カテゴリー</label><br>
-                <%= f.collection_select :category_ids, Category.all, :id, :category_name, include_blank: "選択して下さい" %>
+                <%= f.collection_select :category_ids, @category_options, :id, :category_name, include_blank: "選択して下さい" %>
                 <%= link_to categories_index_path(user_book: @userBook.id), "data-turbolinks": false, class: "btn btn-default edit" do %>
                     カテゴリー名を編集する<%= image_tag 'pencil-plus.png'%>
                 <% end %>

--- a/app/views/user_books/index.html.erb
+++ b/app/views/user_books/index.html.erb
@@ -19,7 +19,7 @@
         <h1>登録した本の検索</h1>
         <%= form_with url: search_path, method: :get, local: true do |f| %>
           <%= f.text_field :keyword, value: @keyword, placeholder: "タイトル・著者名" %><br>
-          <%= f.collection_select :category_ids, Category.all, :id, :category_name, include_blank: "カテゴリーを選択して下さい", selected: @category_ids %><br>
+          <%= f.collection_select :category_ids, @category_options, :id, :category_name, include_blank: "カテゴリーを選択して下さい", selected: @category_ids %><br>
           <% # feeling_starsはfeeling_search.vueにて読後感と星の数の選択画面を表示している %>
           <div id="feeling_stars"></div>
           <% # 以下はrubyで作ったフォーマットをvueに渡している。hidden扱い。%>

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -1,7 +1,34 @@
 require 'test_helper'
 
 class CategoriesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @user = users(:one)
+    @other_user = users(:two)
+    @category = Category.create!(category_name: 'My Category', user: @user)
+    @other_category = Category.create!(category_name: 'Other Category', user: @other_user)
+  end
+
+  test 'redirects guests from index' do
+    get categories_index_url
+
+    assert_redirected_to new_user_session_path
+  end
+
+  test 'returns not found when editing another users category' do
+    sign_in @user
+
+    get category_edit_url(@other_category)
+
+    assert_response :not_found
+  end
+
+  test 'returns not found when deleting another users category' do
+    sign_in @user
+
+    assert_no_difference('Category.count') do
+      delete category_destroy_url(@other_category)
+    end
+
+    assert_response :not_found
+  end
 end

--- a/test/controllers/feeling_categories_controller_test.rb
+++ b/test/controllers/feeling_categories_controller_test.rb
@@ -1,7 +1,34 @@
 require 'test_helper'
 
 class FeelingCategoriesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @user = users(:one)
+    @other_user = users(:two)
+    @feeling_category = FeelingCategory.create!(feeling_after_reading: 'Calm', user: @user)
+    @other_feeling_category = FeelingCategory.create!(feeling_after_reading: 'Other Feeling', user: @other_user)
+  end
+
+  test 'redirects guests from index' do
+    get feeling_categories_index_url
+
+    assert_redirected_to new_user_session_path
+  end
+
+  test 'returns not found when editing another users feeling category' do
+    sign_in @user
+
+    get feeling_category_edit_url(@other_feeling_category)
+
+    assert_response :not_found
+  end
+
+  test 'returns not found when deleting another users feeling category' do
+    sign_in @user
+
+    assert_no_difference('FeelingCategory.count') do
+      delete feeling_categories_destroy_url(@other_feeling_category)
+    end
+
+    assert_response :not_found
+  end
 end

--- a/test/controllers/user_books_controller_test.rb
+++ b/test/controllers/user_books_controller_test.rb
@@ -1,9 +1,69 @@
 require 'test_helper'
 
 class UserBooksControllerTest < ActionDispatch::IntegrationTest
-  test "should get new" do
-    get user_books_new_url
-    assert_response :success
+  setup do
+    @user = users(:one)
+    @other_user = users(:two)
+
+    @user_book = UserBook.create!(
+      user: @user,
+      title: 'Owned Book',
+      author: 'Owner Author'
+    )
+    @other_user_book = UserBook.create!(
+      user: @other_user,
+      title: 'Other Book',
+      author: 'Other Author'
+    )
+
+    @shared_category = Category.create!(category_name: 'Shared Category')
+    @user_category = Category.create!(category_name: 'My Category', user: @user)
+    @other_user_category = Category.create!(category_name: 'Other Category', user: @other_user)
   end
 
+  test 'redirects guests from index' do
+    get user_books_url
+
+    assert_redirected_to new_user_session_path
+  end
+
+  test 'returns not found when editing another users book' do
+    sign_in @user
+
+    get edit_user_book_url(@other_user_book)
+
+    assert_response :not_found
+  end
+
+  test 'returns not found when deleting another users book' do
+    sign_in @user
+
+    assert_no_difference('UserBook.count') do
+      delete user_book_url(@other_user_book)
+    end
+
+    assert_response :not_found
+  end
+
+  test 'edit page shows only shared and owned categories' do
+    sign_in @user
+
+    get edit_user_book_url(@user_book)
+
+    assert_response :success
+    assert_match 'Shared Category', response.body
+    assert_match 'My Category', response.body
+    assert_no_match 'Other Category', response.body
+  end
+
+  test 'search page shows only shared and owned categories' do
+    sign_in @user
+
+    get search_url
+
+    assert_response :success
+    assert_match 'Shared Category', response.body
+    assert_match 'My Category', response.body
+    assert_no_match 'Other Category', response.body
+  end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,11 +1,9 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+one:
+  name: User One
+  email: user-one@example.com
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
 
-# This model initially had no columns defined. If you add columns to the
-# model remove the '{}' from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-# column: value
+two:
+  name: User Two
+  email: user-two@example.com
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,3 +11,7 @@ class ActiveSupport::TestCase
 
   # Add more helper methods to be used by all tests here...
 end
+
+class ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+end


### PR DESCRIPTION
## 概要
- 本・カテゴリー・読後感の編集と削除を、ログイン中ユーザー自身のデータのみに制限
- カテゴリー選択肢を共通カテゴリーとログイン中ユーザーのカテゴリーのみに制限
- 認証、認可、カテゴリー表示範囲に関する回帰テストを追加

## テスト
- `DISABLE_SPRING=1 bundle exec rails test test/controllers/user_books_controller_test.rb test/controllers/categories_controller_test.rb test/controllers/feeling_categories_controller_test.rb`
  - ローカルでは MySQL が `/tmp/mysql.sock` で利用できず未実行