### PR TITLE
Add development memo docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ node_modules
 # https://vitejs.dev/guide/env-and-mode.html#env-files
 *.local
 
+.DS_Store

--- a/Memo/2026-05-01_fix_memo.md
+++ b/Memo/2026-05-01_fix_memo.md
@@ -1,0 +1,95 @@
+# 2026-05-01 Fix Memo
+
+## 概要
+
+2026年4月30日から2026年5月1日にかけて、Docker 起動まわりと本一覧ページの表示崩れを修正した。
+
+## 1. `docker compose up` の起動エラー対応
+
+### 症状
+
+- `docker compose up` 実行時に `web` コンテナが起動直後に終了した
+- エラーログ:
+  - `Could not find gem 'aws-sdk-s3' in locally installed gems.`
+
+### 原因
+
+- `docker-compose.yml` の `web` サービスで `/usr/local/bundle` を volume マウントしていた
+- そのため、イメージビルド時に入っていた gem よりも、実行時 volume の状態が優先された
+- `Gemfile` に `aws-sdk-s3` を追加したあと、起動コマンド側で `bundle install` が走らないため、不足 gem のまま Rails 起動に進んで落ちていた
+
+### 対応
+
+- `docker-compose.yml` の `web.command` を修正した
+- 変更前:
+  - `bundle exec rails db:prepare && bundle exec rails server ...`
+- 変更後:
+  - `bundle check || bundle install` を先に実行してから `db:prepare` と `rails server` を実行
+
+### 結果
+
+- `docker compose up` で `Bundle complete!` のあとに Puma が起動することを確認
+- Rails は `http://0.0.0.0:3000` で listen するところまで到達
+
+## 2. 本一覧ページのレイアウト修正
+
+### 症状
+
+- 本一覧ページが全体的に左へ寄って見えていた
+- 一覧カード内の操作ボタン配置が弱く、`削除` 導線も見えない状態だった
+- 画像未登録時の見た目も崩れやすかった
+
+### 対応
+
+- `app/views/user_books/index.html.erb`
+  - Bootstrap の `row` / `col` 依存が強い構造を整理
+  - 一覧ページ全体を `user-books-page` ラッパーで囲んで中央寄せしやすい構成に変更
+  - 各本を 1 枚のカードとして扱うマークアップに変更
+  - `詳細・編集` と `削除` を右側の操作エリアにまとめて配置
+  - 画像が無い場合は `NO IMAGE` プレースホルダを表示するように変更
+
+- `app/assets/stylesheets/user_books.scss`
+  - 本一覧ページ専用スタイルを追加
+  - 検索エリアを中央寄せし、最大幅を付与
+  - 一覧カードを `画像 / 本文 / 操作` の 3 カラム構成に変更
+  - モバイル幅では縦積みになるレスポンシブ指定を追加
+  - `削除` ボタン専用の色を追加
+
+## 3. SassC エラー修正
+
+### 症状
+
+- `Home#top` 表示時に以下のエラーが発生した
+- `SassC::SyntaxError`
+- 内容:
+  - `"calc(100% - 32px)" is not a number for min`
+
+### 原因
+
+- `app/assets/stylesheets/user_books.scss` で CSS 関数の `min()` を使用していた
+- SassC がこれを CSS の `min()` ではなく Sass 関数として解釈し、引数型エラーになっていた
+
+### 対応
+
+- `min(...)` を使っていた箇所をすべて `width` と `max-width` の組み合わせへ変更
+- 修正例:
+  - `width: min(760px, 100%)`
+  - ↓
+  - `width: 100%`
+  - `max-width: 760px`
+
+### 結果
+
+- SassC のコンパイルエラーを解消
+- レイアウト意図は維持したまま、既存の Rails + SassC 構成で通る形に変更
+
+## 4. 今回変更した主なファイル
+
+- [docker-compose.yml](docker-compose.yml)
+- [app/views/user_books/index.html.erb](app/views/user_books/index.html.erb)
+- [app/assets/stylesheets/user_books.scss](app/assets/stylesheets/user_books.scss)
+
+## 5. 補足
+
+- 本一覧の見た目はコード上で調整済みだが、最終的な余白やボタン位置はブラウザで実画面確認しながら微調整していくのが前提
+- Docker 起動時に gem が増えた場合でも、今の compose 設定なら初回起動時に自動インストールされる


### PR DESCRIPTION
gitの使い方の復習がてら、変更点のログを読み返せるよう、Memoディレクトリを追加した。
2026-05-01　codexに修正してもらった内容を残す。
　・`docker compose up` 実行時に `web` コンテナが起動直後に終了した
　・一覧カード内の削除ボタンが見えない状態だった
　・SassC エラー修正
