### PR TITLE
Fix/category create button

### DIFF
--- a/Memo/2026-06-07_codex_review.md
+++ b/Memo/2026-06-07_codex_review.md
@@ -1,0 +1,257 @@
+# Categories機能 コードレビュー結果
+
+レビュー日時: 2026-06-07
+
+## 概要
+
+* コード変更: なし
+* Critical: なし
+* Warning: 5件
+* Suggestion: 6件
+
+---
+
+# Critical
+
+該当なし
+
+---
+
+# Warning
+
+## 1. update時のバリデーションエラーで500になる可能性
+
+**対象**
+
+* `app/controllers/categories_controller.rb:16`
+
+**内容**
+
+更新処理で `save!` を使用しているため、空文字や重複名などのバリデーションエラーが発生すると例外が発生し、500エラーになる可能性がある。
+
+**推奨対応**
+
+`create` と同様に失敗時のハンドリングを実装する。
+
+```ruby
+render :index, status: :unprocessable_entity
+```
+
+---
+
+## 2. Turboキャッシュ復元時のVue再初期化問題
+
+**対象**
+
+* `app/frontend/entrypoints/modal_vue.js:16`
+* `app/frontend/entrypoints/modal_vue.js:23`
+
+**内容**
+
+`data-vue-mounted` を利用した初期化制御は、Turboのキャッシュ復元時に問題になる可能性がある。
+
+TurboのSnapshotにはDOM属性が保存されるが、Vueのイベントリスナーは復元されないため、
+
+* 戻る
+* 進む
+
+操作後に「カテゴリーを追加する」ボタンが反応しなくなる可能性がある。
+
+**推奨対応**
+
+`turbo:before-cache` イベントでVueを `unmount` する設計を検討する。
+
+---
+
+## 3. 作成エラー時はTurbo再描画ではない
+
+**対象**
+
+* `app/views/categories/index.html.erb:35`
+
+**内容**
+
+フォームに
+
+```erb
+data: { turbo: false }
+```
+
+が設定されているため、作成失敗時の
+
+```ruby
+render :index
+```
+
+はTurboによる描画ではなく通常のフルページロードになる。
+
+そのためVueは通常のページロードとして再初期化される。
+
+**補足**
+
+「Turboでrender後にVueが再初期化されるか」の検証対象にはならない。
+
+---
+
+## 4. category_id許可によるUnknownAttributeErrorの可能性
+
+**対象**
+
+* `app/controllers/categories_controller.rb:23`
+* `app/controllers/categories_controller.rb:47`
+
+**内容**
+
+`Category.new(categories_params)` において、Strong Parametersで `category_id` が許可されている。
+
+しかし `categories` テーブルには `category_id` カラムが存在しないため、
+
+```ruby
+UnknownAttributeError
+```
+
+が発生する可能性がある。
+
+**推奨対応**
+
+作成用と更新用でStrong Parametersを分離する。
+
+---
+
+## 5. Bootstrap Navbarが動作しない可能性
+
+**対象**
+
+* `app/views/layouts/application.html.erb:30`
+
+**内容**
+
+Bootstrap Collapse を使用しているが、レビュー範囲ではBootstrap JavaScriptの読み込みが確認できなかった。
+
+**影響**
+
+モバイル表示時のNavbar Toggleボタンが動作しない可能性がある。
+
+---
+
+# Suggestion
+
+## 1. 変数名の命名規則
+
+**対象**
+
+* `app/controllers/categories_controller.rb:6`
+* `app/controllers/categories_controller.rb:7`
+
+**内容**
+
+```ruby
+@defaultCategories
+```
+
+よりも
+
+```ruby
+@default_categories
+```
+
+の方がRails/Rubyの慣習に沿っている。
+
+---
+
+## 2. current_user.categoriesの利用
+
+**対象**
+
+* `app/controllers/categories_controller.rb:7`
+
+**内容**
+
+現在の記述よりも
+
+```ruby
+current_user.categories.order(:id)
+```
+
+の方がRailsらしく意図が明確。
+
+---
+
+## 3. Rubyインデント
+
+**対象**
+
+* `app/models/category.rb:4`
+
+**内容**
+
+4スペースインデントになっている。
+
+Rails標準は2スペース。
+
+---
+
+## 4. category-buttonの重複定義
+
+**対象**
+
+* `app/assets/stylesheets/custom.scss:480`
+* `app/assets/stylesheets/custom.scss:490`
+
+**内容**
+
+`.category-button` が複数箇所で定義されている。
+
+**推奨対応**
+
+1箇所に統合して管理する。
+
+---
+
+## 5. data-turbolinksはTurbo Railsでは無効
+
+**対象**
+
+* `app/views/categories/index.html.erb:48`
+* `app/views/layouts/application.html.erb:40`
+
+**内容**
+
+```erb
+data-turbolinks
+```
+
+はTurbo Railsでは機能しない。
+
+Turboを無効化したい場合は
+
+```erb
+data: { turbo: false }
+```
+
+を使用する。
+
+---
+
+## 6. N+1問題
+
+**結果**
+
+今回の差分範囲ではN+1問題は確認されなかった。
+
+理由:
+
+* `@categories.each`
+* 関連モデル参照なし
+
+のため、追加クエリは発生しない。
+
+---
+
+# 優先対応案
+
+1. update時のsave!による500エラー対策
+2. category_id許可の見直し
+3. Turbo + Vueのキャッシュ復元問題の確認
+4. Bootstrap JavaScript読込確認
+5. 命名規則・SCSS整理などのリファクタリング

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -52,7 +52,7 @@ body {
 .btn-default {
   font-family: 'Courier New', Courier, monospace;
   font-size: 16px;
-  color: #fff;
+  color: #fff !important;
   width: 180px;
   height: 40px;
   line-height: 28px;
@@ -477,23 +477,12 @@ body {
   }
 }
 
-.category-button {
-  width: 120px;
-  color: #fff;
-  background-color: rgba(68, 192, 48, 0.62);
-
-  &:hover {
-    background-color: rgba(68, 192, 48, 0.8);
-  }
-}
 
 .category-button {
   display: inline-block;
   padding: 8px 16px;
   background-color: rgba(68, 192, 48, 0.62);
-  color: #fff;
   border-radius: 5px;
-
   width: auto;
   height: auto;
   line-height: normal;

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -77,8 +77,18 @@ body {
   color: #fff;
   &:hover {
     background-color: rgba(46, 115, 131, 0.8);
+    color: #fff;
   }
 }
+
+// flash
+.flash-message {
+  background-color: #f8d7da;
+  border: 1px solid #f5c2c7;
+  padding: 10px;
+  margin: 10px;
+}
+
 
 // topページ
 .btn-green {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -479,6 +479,28 @@ body {
 .category-button {
   width: 120px;
   color: #fff;
+  background-color: rgba(68, 192, 48, 0.62);
+
+  &:hover {
+    background-color: rgba(68, 192, 48, 0.8);
+  }
+}
+
+.category-button {
+  display: inline-block;
+  padding: 8px 16px;
+  background-color: rgba(68, 192, 48, 0.62);
+  color: #fff;
+  border-radius: 5px;
+
+  width: auto;
+  height: auto;
+  line-height: normal;
+  letter-spacing: normal;
+
+  &:hover {
+    background-color: rgba(68, 192, 48, 0.8);
+  }
 }
 
 @media screen and (max-width:480px) { 

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -81,15 +81,6 @@ body {
   }
 }
 
-// flash
-.flash-message {
-  background-color: #f8d7da;
-  border: 1px solid #f5c2c7;
-  padding: 10px;
-  margin: 10px;
-}
-
-
 // topページ
 .btn-green {
   font-family: Work Sans;

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -3,7 +3,7 @@ class CategoriesController < ApplicationController
   before_action :set_category, only: [:edit, :destroy]
 
   def index
-    @defaultCategories = Category.where(user_id: nil)
+    @default_categories = Category.where(user_id: nil)
     @categories = Category.where(user_id: current_user.id).order(:user_id, :id)
   end
   
@@ -24,7 +24,7 @@ class CategoriesController < ApplicationController
     if @category.save
       redirect_to categories_index_url
     else
-      @defaultCategories = Category.where(user_id: nil)
+      @default_categories = Category.where(user_id: nil)
       @categories = Category.where(user_id: current_user.id).order(:user_id, :id)
       render :index, status: :unprocessable_entity
     end
@@ -36,7 +36,7 @@ class CategoriesController < ApplicationController
     if @category.save
       redirect_to categories_index_url
     else
-      @defaultCategories = Category.where(user_id: nil)
+      @default_categories = Category.where(user_id: nil)
       @categories = Category.where(user_id: current_user.id).order(:user_id, :id)
       render :index, status: :unprocessable_entity
     end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -21,12 +21,15 @@ class CategoriesController < ApplicationController
   end
   
   def create
-    @category = Category.find_or_initialize_by(
-      user_id: current_user.id,
-      category_name: categories_params[:category_name]
-      )
-    @category.save!
-    redirect_to categories_index_url
+    @category = Category.new(categories_params)
+    @category.user_id = current_user.id
+    if @category.save
+      redirect_to categories_index_url
+    else
+      @defaultCategories = Category.where(user_id: nil)
+      @categories = Category.where(user_id: current_user.id).order(:user_id, :id)
+      render :index, status: :unprocessable_entity
+    end
   end
   
   def destroy

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -15,7 +15,7 @@ class CategoriesController < ApplicationController
   
   def update
     @category = Category.find_by!(
-      id: categories_params[:category_id],
+      id: params[:category_id],
       user_id: current_user.id
     )
 
@@ -54,6 +54,6 @@ class CategoriesController < ApplicationController
   end
 
   def categories_params
-    params.permit(:category_name, :category_id)
+    params.permit(:category_name)
   end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -14,10 +14,20 @@ class CategoriesController < ApplicationController
   end
   
   def update
-    @category = Category.find_by!(id: categories_params[:category_id], user_id: current_user.id)
+    @category = Category.find_by!(
+      id: categories_params[:category_id],
+      user_id: current_user.id
+    )
+
     @category.category_name = categories_params[:category_name]
-    @category.save!
-    redirect_to categories_index_url
+
+    if @category.save
+      redirect_to categories_index_url
+    else
+      @defaultCategories = Category.where(user_id: nil)
+      @categories = Category.where(user_id: current_user.id).order(:user_id, :id)
+      render :index, status: :unprocessable_entity
+    end
   end
   
   def create

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -4,7 +4,7 @@ class CategoriesController < ApplicationController
 
   def index
     @default_categories = Category.where(user_id: nil)
-    @categories = Category.where(user_id: current_user.id).order(:user_id, :id)
+    @categories = current_user.categories.order(:id)
   end
   
   def new
@@ -25,7 +25,7 @@ class CategoriesController < ApplicationController
       redirect_to categories_index_url
     else
       @default_categories = Category.where(user_id: nil)
-      @categories = Category.where(user_id: current_user.id).order(:user_id, :id)
+      @categories = current_user.categories.order(:id)
       render :index, status: :unprocessable_entity
     end
   end
@@ -37,7 +37,7 @@ class CategoriesController < ApplicationController
       redirect_to categories_index_url
     else
       @default_categories = Category.where(user_id: nil)
-      @categories = Category.where(user_id: current_user.id).order(:user_id, :id)
+      @categories = current_user.categories.order(:id)
       render :index, status: :unprocessable_entity
     end
   end

--- a/app/frontend/components/CategoryForm.vue
+++ b/app/frontend/components/CategoryForm.vue
@@ -1,17 +1,19 @@
 <template>
   <div class="example-modal-window">
     <p>ボタンを押すとモーダルウィンドウが開きます</p>
-    <div @click="openModal">開く</div>
-
+    <button type="button" @click="openModal">カテゴリーを追加する</button>
     <!-- コンポーネント MyModal -->
     <Modal @close="closeModal" v-if="modal">
       <!-- default スロットコンテンツ -->
       <h2>カテゴリーを新規登録する</h2>
-        <input type="text" name="category_name">
+        <input type="text" name="category_name" v-model="categoryName">
       <!-- /default -->
       <!-- footer スロットコンテンツ -->
-      <template slot="footer">
+      <template #footer>
         <input type="submit" value="新規登録する">
+        <button type="button" @click="closeModal">
+          閉じる
+        </button>
       </template>
       <!-- /footer -->
     </Modal>
@@ -25,6 +27,7 @@ export default {
   data() {
     return {
       modal: false,
+      categoryName: '',
     }
   },
   methods: {

--- a/app/frontend/components/CategoryForm.vue
+++ b/app/frontend/components/CategoryForm.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="example-modal-window">
     <p>ボタンを押すとモーダルウィンドウが開きます</p>
-    <button type="button" @click="openModal">カテゴリーを追加する</button>
+    <button class="btn btn-default category-button" type="button" @click="openModal">カテゴリーを追加する</button>
     <!-- コンポーネント MyModal -->
     <Modal @close="closeModal" v-if="modal">
       <!-- default スロットコンテンツ -->

--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -1,1 +1,2 @@
 import "@hotwired/turbo-rails"
+import "./modal_vue"

--- a/app/frontend/entrypoints/modal_vue.js
+++ b/app/frontend/entrypoints/modal_vue.js
@@ -11,16 +11,16 @@ const vuetify = createVuetify({
 })
 
 const mountModalForm = () => {
-
-  const app = createApp(CategoryForm)
   const element = document.getElementById('modal-form')
 
   if (!element || element.dataset.vueMounted === 'true') return
 
+  const app = createApp(CategoryForm)
+
   app.use(vuetify)
   app.mount(element)
+
   element.dataset.vueMounted = 'true'
 }
 
-document.addEventListener('DOMContentLoaded', mountModalForm)
 document.addEventListener('turbo:load', mountModalForm)

--- a/app/frontend/entrypoints/modal_vue.js
+++ b/app/frontend/entrypoints/modal_vue.js
@@ -10,23 +10,10 @@ const vuetify = createVuetify({
   directives,
 })
 
-// const mountModalForm = () => {
-//   const app = createApp(CategoryForm)
-//   const element = document.getElementById('modal-form')
-//   if (!element || element.dataset.vueMounted === 'true') return
-
-//   app.use(vuetify)
-//   app.mount(element)
-//   element.dataset.vueMounted = 'true'
-// }
-
 const mountModalForm = () => {
-  console.log("mountModalForm called")
 
   const app = createApp(CategoryForm)
   const element = document.getElementById('modal-form')
-
-  console.log(element)
 
   if (!element || element.dataset.vueMounted === 'true') return
 

--- a/app/frontend/entrypoints/modal_vue.js
+++ b/app/frontend/entrypoints/modal_vue.js
@@ -10,12 +10,14 @@ const vuetify = createVuetify({
   directives,
 })
 
+let app = null
+
 const mountModalForm = () => {
   const element = document.getElementById('modal-form')
 
   if (!element || element.dataset.vueMounted === 'true') return
 
-  const app = createApp(CategoryForm)
+  app = createApp(CategoryForm)
 
   app.use(vuetify)
   app.mount(element)
@@ -24,3 +26,16 @@ const mountModalForm = () => {
 }
 
 document.addEventListener('turbo:load', mountModalForm)
+
+document.addEventListener('turbo:before-cache', () => {
+  const element = document.getElementById('modal-form')
+
+  if (app) {
+    app.unmount()
+    app = null
+  }
+
+  if (element) {
+    delete element.dataset.vueMounted
+  }
+})

--- a/app/frontend/entrypoints/modal_vue.js
+++ b/app/frontend/entrypoints/modal_vue.js
@@ -10,9 +10,24 @@ const vuetify = createVuetify({
   directives,
 })
 
+// const mountModalForm = () => {
+//   const app = createApp(CategoryForm)
+//   const element = document.getElementById('modal-form')
+//   if (!element || element.dataset.vueMounted === 'true') return
+
+//   app.use(vuetify)
+//   app.mount(element)
+//   element.dataset.vueMounted = 'true'
+// }
+
 const mountModalForm = () => {
+  console.log("mountModalForm called")
+
   const app = createApp(CategoryForm)
   const element = document.getElementById('modal-form')
+
+  console.log(element)
+
   if (!element || element.dataset.vueMounted === 'true') return
 
   app.use(vuetify)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,6 @@
 class Category < ApplicationRecord
-    has_many :user_categories, dependent: :destroy
-    has_many :user_books, through: :user_categories
-    validates :category_name, presence: true
-    validates :category_name, uniqueness: { scope: :user_id }
+  has_many :user_categories, dependent: :destroy
+  has_many :user_books, through: :user_categories
+  validates :category_name, presence: true
+  validates :category_name, uniqueness: { scope: :user_id }
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,6 @@
 class Category < ApplicationRecord
     has_many :user_categories, dependent: :destroy
     has_many :user_books, through: :user_categories
+    validates :category_name, presence: true
+    validates :category_name, uniqueness: { scope: :user_id }
 end

--- a/app/models/feeling_category.rb
+++ b/app/models/feeling_category.rb
@@ -1,5 +1,5 @@
 class FeelingCategory < ApplicationRecord
-    has_many :user_feeling_categories, dependent: :destroy 
-    has_many :user_books, through: :user_feeling_categories
-    validates :feeling_after_reading, presence: true
+  has_many :user_feeling_categories, dependent: :destroy 
+  has_many :user_books, through: :user_feeling_categories
+  validates :feeling_after_reading, presence: true
 end

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -19,7 +19,7 @@
             <%= form_tag(categories_update_path, method: :post) do %>
               <input type="text" name="category_name" value="<%= category.category_name %>">
               <input type="hidden" name="category_id" value="<%= category.id %>">
-              <button type="submit">更新する</button>
+              <button class="btn-default edit" type="submit">更新する</button>
             <% end %>
           </div>
 
@@ -27,14 +27,23 @@
             <%= button_to "削除する",
               category_destroy_path(category.id),
               method: :delete,
-              data: { turbo_confirm: "削除してもよろしいですか？" } %>
+              data: { turbo_confirm: "削除してもよろしいですか？" },
+              class: 'btn btn-default delete' %>
           </div>
         <% end %>
       </div>
       
       <div class="create-category">
-        <%= form_tag(categories_create_path, method: :post) do %>
+        <%= form_tag(categories_create_path, method: :post, data: { turbo: false }) do %>
           <div id="modal-form"></div>
+        <% end %>
+
+        <% if @category&.errors&.any? %>
+          <% @category.errors.full_messages.each do |message| %>
+            <div class="error-message">
+              <%= message %>
+            </div>
+          <% end %>
         <% end %>
       </div>
       <% if params[:user_book] %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -4,9 +4,9 @@
     <div class="categories">
       <div class="default-categories">
         <h2>既存のカテゴリー</h2>
-        <% @defaultCategories.each do |defaultCategory| %>
+        <% @default_categories.each do |default_category| %>
           <div>
-            <%= defaultCategory.category_name %>
+            <%= default_category.category_name %>
           </div>
         <% end %>
       </div>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,4 +1,3 @@
-<%= vite_javascript_tag 'modal_vue' %>
 <% content_for :description do %>登録されているカテゴリーの一覧ページです。カテゴリーの新規登録もできます。<% end %>   
 <div class="categories-wrapper">
   <div class="container">
@@ -11,7 +10,6 @@
           </div>
         <% end %>
       </div>
-      <%= link_to "カテゴリーを追加する", new_category_path, class: "btn btn-default category-button" %>
       <div class="edit-categories">  
         <h2>カテゴリーを編集する</h2>
         <% @categories.each do |category| %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,27 +1,63 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
   <head>
     <title>BookRecipeNext</title>
+
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+
     <%= vite_client_tag %>
     <%= vite_javascript_tag 'application' %>
-    <!--
-      If using a TypeScript entrypoint file:
-        vite_typescript_tag 'application'
 
-      If using a .jsx or .tsx entrypoint, add the extension:
-        vite_javascript_tag 'application.jsx'
-
-      Visit the guide for more information: https://vite-ruby.netlify.app/guide/rails
-    -->
-
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Bitter:wght@700&display=swap" rel="stylesheet">
   </head>
 
   <body>
+    <header>
+      <% if user_signed_in? %>
+        <nav class="navbar navbar-expand-lg navbar-light" style="background-color:#F6FFBD;">
+        <div class="container-fluid">
+          <%= link_to root_path, class: 'navbar-brand' do %>
+            <span><%= image_tag 'logo2-3.png', class: "logo img-fluid", alt: "", width: "240", height: "53.5" %></span>
+          <% end %>
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+
+          <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">  
+              <li class="nav-item">
+                <span class="navbar-text d-inline-block align-top"><%= current_user.name %></span>
+              </li>
+              <li class="nav-item">
+                <%= link_to 'カテゴリーの編集', categories_index_url, class: 'nav-link' %>
+              </li>
+              <li class="nav-item">
+                <%= link_to '読後感の編集', feeling_categories_index_url, class: 'nav-link' %>
+              </li>
+              <li class="nav-item">
+                <%= link_to 'ログアウト', destroy_user_session_url, method: :delete, class: 'nav-link' %>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </nav>
+      <% end %>
+
+      <% flash.each do |key, value| %>
+        <div class="flash-message">
+          <%= value %>
+        </div>
+      <% end %>
+    </header>
+
     <%= yield %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,6 +37,9 @@
                 <span class="navbar-text d-inline-block align-top"><%= current_user.name %></span>
               </li>
               <li class="nav-item">
+                <%= link_to '本の登録', user_books_path, data: {"turbolinks"=>false}, class: 'nav-link' %>
+              </li>
+              <li class="nav-item">
                 <%= link_to 'カテゴリーの編集', categories_index_url, class: 'nav-link' %>
               </li>
               <li class="nav-item">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,18 +43,12 @@
                 <%= link_to '読後感の編集', feeling_categories_index_url, class: 'nav-link' %>
               </li>
               <li class="nav-item">
-                <%= link_to 'ログアウト', destroy_user_session_url, method: :delete, class: 'nav-link' %>
+                <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: 'nav-link' %>
               </li>
             </ul>
           </div>
         </div>
       </nav>
-      <% end %>
-
-      <% flash.each do |key, value| %>
-        <div class="flash-message">
-          <%= value %>
-        </div>
       <% end %>
     </header>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module BookRecipeNext
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
+    config.i18n.default_locale = :ja
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  activerecord:
+    models:
+      category: カテゴリー
+
+    attributes:
+      category:
+        category_name: カテゴリー名


### PR DESCRIPTION
・カテゴリー追加ボタンとVueを使ったモーダルを整えて、カテゴリーをモーダルで新規登録できるようにした。
・カテゴリー新規登録の際に空行だったり、全く同じカテゴリーを二重登録できないようバリデーションを整えて、登録が失敗した際にエラーメッセージが出るようにした。

・共通ヘッダーを復活させた。

・categories_controllerのupdate失敗時のエラーハンドリングを整えた。

・Turboキャッシュを復元した際に、Vueで作ったカテゴリー新規登録モーダルが表示されなくなるというバグを修正した。